### PR TITLE
Adding initial swagger initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+              <groupId>com.wordnik</groupId>
+              <artifactId>swagger-jaxrs_2.10</artifactId>
+              <version>1.3.12</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <scope>test</scope>

--- a/reports-rest/pom.xml
+++ b/reports-rest/pom.xml
@@ -35,5 +35,9 @@
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.wordnik</groupId>
+            <artifactId>swagger-jaxrs_2.10</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/reports-rest/src/main/java/org/jboss/da/listings/rest/RestActivator.java
+++ b/reports-rest/src/main/java/org/jboss/da/listings/rest/RestActivator.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
+import com.wordnik.swagger.jaxrs.config.BeanConfig;
 import org.jboss.da.listings.rest.impl.ArtifactsImpl;
 
 /**
@@ -17,7 +18,19 @@ import org.jboss.da.listings.rest.impl.ArtifactsImpl;
 @ApplicationPath("/rest")
 public class RestActivator extends Application {
 
-    private static Class<?>[] restClasses = new Class<?>[] { RootImpl.class, ArtifactsImpl.class };
+    private static Class<?>[] restClasses = new Class<?>[] { RootImpl.class, ArtifactsImpl.class,
+            com.wordnik.swagger.jaxrs.listing.ApiListingResource.class,
+            com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider.class,
+            com.wordnik.swagger.jaxrs.listing.ApiListingResourceJSON.class,
+            com.wordnik.swagger.jaxrs.listing.ResourceListingProvider.class };
+
+    public RestActivator() {
+        BeanConfig beanConfig = new BeanConfig();
+        beanConfig.setVersion("1.0.0");
+        beanConfig.setBasePath("http://localhost:8080/api");
+        beanConfig.setResourcePackage("io.swagger.resources");
+        beanConfig.setScan(true);
+    }
 
     @Override
     public Set<Class<?>> getClasses() {


### PR DESCRIPTION
This should enable swagger for reports-rest. Right now we'll have to manually specify which rest class should be scanned for swagger annotations. Will add more code as the PRs for REST endpoints get merged.