### PR TITLE
Activate Reports JAX-RS class

### DIFF
--- a/reports-rest/README.md
+++ b/reports-rest/README.md
@@ -1,0 +1,14 @@
+# reports-rest
+
+The `reports-rest` module is used to provide REST endpoints to:
+
+- obtain listings of white and black artifacts
+- get dependency information of a project or GAV.
+
+## Documentation
+The REST endpoints are documented using [Swagger](http://swagger.io/)
+
+## Adding a new JAX-RS class
+Swagger imposes some restrictions on automatic scanning of JAX-RS classes. As
+such, for now we'll have to specify the JAX-RS classes we want to activate in
+the `ReportsRestActivator` class, method `addProjectResources`.

--- a/reports-rest/src/main/java/org/jboss/da/rest/ReportsRestActivator.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/ReportsRestActivator.java
@@ -1,30 +1,48 @@
 package org.jboss.da.rest;
 
 import org.jboss.da.rest.listings.Artifacts;
+import org.jboss.da.rest.reports.Reports;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * 
+ *
  * @author Jozef Mrazek <jmrazek@redhat.com>
  *
  */
 @ApplicationPath("/rest")
 public class ReportsRestActivator extends Application {
 
-    private static Class<?>[] restClasses = new Class<?>[] { Root.class, Artifacts.class,
-    com.wordnik.swagger.jaxrs.listing.ApiListingResource.class,
-    com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider.class,
-    com.wordnik.swagger.jaxrs.listing.ApiListingResourceJSON.class,
-    com.wordnik.swagger.jaxrs.listing.ResourceListingProvider.class};
-
     @Override
     public Set<Class<?>> getClasses() {
-        return new HashSet<Class<?>>(Arrays.asList(restClasses));
+        Set<Class<?>> resources = new HashSet<>();
+        addSwaggerResources(resources);
+        addProjectResources(resources);
+        return resources;
+    }
+
+    /**
+     * Swagger classes required to generate the API JSON generation
+     * @param resources
+     */
+    public void addSwaggerResources(Set<Class<?>> resources) {
+        resources.add(com.wordnik.swagger.jaxrs.listing.ApiListingResource.class);
+        resources.add(com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider.class);
+        resources.add(com.wordnik.swagger.jaxrs.listing.ApiListingResourceJSON.class);
+        resources.add(com.wordnik.swagger.jaxrs.listing.ResourceListingProvider.class);
+    }
+
+    /**
+     * Add all JAX-RS classes here to get activated!
+     * @param resources
+     */
+    public void addProjectResources(Set<Class<?>> resources) {
+        resources.add(Root.class);
+        resources.add(Artifacts.class);
+        resources.add(Reports.class);
     }
 }

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -1,5 +1,7 @@
 package org.jboss.da.rest.reports;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 import org.jboss.da.reports.api.GAV;
 import org.jboss.da.reports.backend.api.VersionFinder;
 import org.jboss.da.rest.reports.model.GAVRequest;
@@ -25,6 +27,7 @@ import java.util.List;
  *
  */
 @Path("/reports")
+@Api(value = "/reports", description = "Get report of dependencies of projects")
 public class Reports {
 
     @Inject
@@ -34,6 +37,7 @@ public class Reports {
     @Path("/scm")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get dependency report for a project specified in a repository url")
     public Report scmGenerator(SCMRequest scmRequest) {
         // TODO Auto-generated method stub
         return null;
@@ -43,6 +47,7 @@ public class Reports {
     @Path("/gav")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get dependency report for a GAV")
     public Report gavGenerator(GAVRequest gavRequest) {
         // TODO Auto-generated method stub
         return null;
@@ -52,6 +57,7 @@ public class Reports {
     @Path("/lookup/gav")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get best matching version for the list of GAVs provided")
     public List<LookupReport> lookupGav(List<GAV> gavRequest) {
         List<LookupReport> reportsList = new ArrayList<>();
         gavRequest.forEach((gav) -> reportsList.add(toLookupReport(gav)));


### PR DESCRIPTION
Refactored a little bit `ReportsRestActivator.java` so that it's easier to add new JAX-RS classes to the set of classes.

Also added the `Reports.class` class to the set of classes, so that the JAX-RS endpoint `/reports` is activated.