### PR TITLE
Fix the unmarshalling error in the reports-rest '/lookup/gav' endpoint

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/model/GA.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/model/GA.java
@@ -2,11 +2,13 @@ package org.jboss.da.communication.aprox.model;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @EqualsAndHashCode
+@NoArgsConstructor
 @RequiredArgsConstructor
 public class GA {
 

--- a/communication/src/main/java/org/jboss/da/communication/aprox/model/GAV.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/model/GAV.java
@@ -1,8 +1,10 @@
 package org.jboss.da.communication.aprox.model;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@NoArgsConstructor
 public class GAV extends GA {
 
     public GAV(String groupId, String artifactId, String version) {


### PR DESCRIPTION
The unmarshalling error occured because the `GAV` class has a default
constructor that requires arguments.

Jackson requires the Java POJOs to have a 'no arguments' constructor to be
able to match the JSON structure to a JAVA POJO (https://github.com/FasterXML/jackson-annotations#using-constructors-or-factory-methods). Since the `GAV`
class previously had **no** 'no arguments' constructor, the matching failed.

By adding the `@NoArgsConstructor` to the `GAV` class, a 'no arguments'
constructor is created, which makes Jackson happy.

No tests are provided for this commit. However in the future integration
tests will be added to those REST endpoints to catch these kinds of
errors.

The commit was verified manually using the Swagger UI [[http://localhost:8080/reports-rest/swagger-ui/#!/reports/lookupGav]](http://localhost:8080/reports-rest/swagger-ui/#!/reports/lookupGav).

Fixes DA-80
[1]: https://github.com/FasterXML/jackson-annotations#using-constructors-or-factory-methods
[2]: http://localhost:8080/reports-rest/swagger-ui/#!/reports/lookupGav