### PR TITLE
Move from Aprox group to Aprox remote

### DIFF
--- a/common/src/main/java/org/jboss/da/common/json/DAConfig.java
+++ b/common/src/main/java/org/jboss/da/common/json/DAConfig.java
@@ -35,6 +35,6 @@ public class DAConfig {
 
     @Getter
     @Setter
-    private String aproxGroup;
+    private String aproxRemote;
 
 }

--- a/common/src/main/resources/da-config.json
+++ b/common/src/main/resources/da-config.json
@@ -6,5 +6,5 @@
   "keycloakRealm": "",
   "pncServer": "",
   "aproxServer": "",
-  "aproxGroup": ""
+  "aproxRemote": ""
 }

--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -43,8 +43,8 @@ public class AproxConnectorImpl implements AproxConnector {
         StringBuilder query = new StringBuilder();
         try {
             query.append(config.getConfig().getAproxServer());
-            query.append("group/");
-            query.append(config.getConfig().getAproxGroup()).append('/');
+            query.append("/api/remote/");
+            query.append(config.getConfig().getAproxRemote()).append('/');
             query.append(ga.getGroupId().replace(".", "/")).append("/");
             query.append(ga.getArtifactId()).append('/');
             query.append("maven-metadata.xml");

--- a/testsuite/src/test/java/org/jboss/da/test/communication/AproxTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/communication/AproxTest.java
@@ -30,13 +30,14 @@ public class AproxTest {
 
     @Test
     public void testGetVersionsOfGA() throws CommunicationException {
-        GA ga = new GA("org.jboss.apiviz", "apiviz");
-        List<String> apivizTest = Arrays.asList(new String[] { "1.3.1.GA-redhat-1", "1.2.5.GA",
-                "1.3.0.GA", "1.3.1.GA-redhat-2", "1.3.2.GA" });
+        GA ga = new GA("org.jboss.ballroom", "ballroom");
+        List<String> ballroomTest = Arrays.asList(new String[] { "1.3.0.Final-redhat-1",
+                "1.4.0.Final-redhat-1", "1.6.0.Final-redhat-1" });
         List<String> result = aproxConnector.getVersionsOfGA(ga);
-        assertTrue(apivizTest.size() == result.size());
-        assertTrue(apivizTest.containsAll(result));
-        assertTrue(result.containsAll(apivizTest));
+        assertTrue(result.size() > 0);
+        // future releases might make the size of result to be bigger
+        assertTrue(ballroomTest.size() <= result.size());
+        assertTrue(result.containsAll(ballroomTest));
     }
 
 }


### PR DESCRIPTION
We have decided to use the Aprox remote feature instead of the Aprox
group feature for now. Later on we might go back to the group feature.

Note: the da-config.json structure was changed as a result of this change. Please consult the deployment document for the new values.

DA-81