### PR TITLE
Allow `bestMatchVersion` to be null

### DIFF
--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/model/LookupReport.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/model/LookupReport.java
@@ -3,10 +3,10 @@ package org.jboss.da.rest.reports.model;
 import org.jboss.da.communication.aprox.model.GAV;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.Setter;
 
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class LookupReport {
 
     @Getter
@@ -16,7 +16,6 @@ public class LookupReport {
 
     @Getter
     @Setter
-    @NonNull
     private String bestMatchVersion;
 
 }


### PR DESCRIPTION
Currently, the lombok annotations prevent the `bestMatchVersion` field to be null. This PR changes that behavior so that we can return `null` as JSON value to the key `bestMatchVersion`, instead of getting a `NullPointerException`

JIRA: DA-82, DA-75, DA-76