### PR TITLE
[DA-87] bug fix: available versions in report contains null

### DIFF
--- a/reports-backend/src/main/java/org/jboss/da/reports/api/ArtifactReport.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/ArtifactReport.java
@@ -48,7 +48,9 @@ public class ArtifactReport {
     private boolean whiteListed;
 
     public void setBestMatchVersion(String version) {
-        availableVersions.add(version);
+        if (version != null) {
+            availableVersions.add(version);
+        }
         bestMatchVersion = version;
     }
 

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/TestReportsGenerator.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/TestReportsGenerator.java
@@ -171,6 +171,17 @@ public class TestReportsGenerator {
     }
 
     @Test
+    public void artifactReportShouldNotHaveNullValuesInAvailableVersionsWhenBestMatchVersionIsNull()
+            throws CommunicationException {
+        prepare(false, false, daCoreVersionsBest, null, daCoreNoDT);
+        ArtifactReport report = generator.getReport(daCoreGAV);
+        assertNotNull(report);
+        assertNull(report.getBestMatchVersion());
+
+        assertFalse(report.getAvailableVersions().stream().anyMatch(version -> version == null));
+    }
+
+    @Test
     @Ignore
     // TODO: Remove this ignore when AProxCommunicator supports dependencies
     public void testGetMultipleReport() throws CommunicationException {


### PR DESCRIPTION
This situation occurs if the `bestMatchVersion` is also null. This
occurs when no best match is found.

Previously even if the best match was null, it was also added to the
available versions when calling `setBestMatchVersion` in `ArtifactReport`.

This commit now checks if the best match is *not null* before adding it to
the set of available versions. It still allows `bestMatchVersion` to be
set to null though, since we might have legitimate reasons to set
`bestMatchVersion` to null.

The unit test basically sets the `bestMatchVersion` to null, and we scan
the versions in `getAvailableVersions()` to make sure that no element in
the set is null.