### PR TITLE
[DA-93] Add pom-report option

### DIFF
--- a/cli/da-cli-admin.sh
+++ b/cli/da-cli-admin.sh
@@ -14,8 +14,10 @@ printUsage() {
     echo "    Delete artifact GROUP_ID:ARTIFACT_ID:VERSION from black or white list"
     echo "$0 list (b[lack]|w[hite])"
     echo "    List all artifacts in black or white list"
-    echo "$0 pom [--no-transitive]";
+    echo "$0 pom-bw [--no-transitive]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status"
+    echo "$0 pom-report [--no-transitive]";
+    echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status"
     echo "$0 lookup";
     echo "    Read G:A:Vs from standard input and finds corresponding redhat versions"
     echo "$0 report GROUP_ID:ARTIFACT_ID:VERSION";
@@ -23,7 +25,7 @@ printUsage() {
     exit
 }
 
-    
+
 if [ $# -lt 1 ]; then
     printUsage
     exit
@@ -36,7 +38,8 @@ case $action in
     delete) deleteGAVFromList $2 $3;;
     check) check $2 $3;;
     list) list $2;;
-    pom) pom $2;;
+    pom-bw) pom_bw $2;;
+    pom-report) pom_report $2;;
     lookup) lookup;;
     report) report $2;;
     *) printUsage ;;

--- a/cli/da-cli.sh
+++ b/cli/da-cli.sh
@@ -10,8 +10,10 @@ printUsage() {
     echo "    Check if artifact GROUP_ID:ARTIFACT_ID:VERSION is in black or white list"
     echo "$0 list (b[lack]|w[hite])"
     echo "    List all artifacts in black or white list"
-    echo "$0 pom [--no-transitive]";
+    echo "$0 pom-bw [--no-transitive]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status"
+    echo "$0 pom-report [--no-transitive]";
+    echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status"
     echo "$0 lookup";
     echo "    Read G:A:Vs from standard input and finds corresponding redhat versions"
     echo "$0 report GROUP_ID:ARTIFACT_ID:VERSION";
@@ -19,7 +21,7 @@ printUsage() {
     exit
 }
 
-    
+
 if [ $# -lt 1 ]; then
     printUsage
     exit
@@ -30,7 +32,8 @@ action=$1
 case $action in
     check) check $2 $3;;
     list) list $2;;
-    pom) pom $2;;
+    pom-bw) pom_bw $2;;
+    pom-report) pom_report $2;;
     lookup) lookup;;
     report) report $2;;
     *) printUsage ;;

--- a/cli/listings.sh
+++ b/cli/listings.sh
@@ -28,7 +28,6 @@ get() {
 }
 
 post() {
-    echo curl -s -H "Content-Type: application/json" -X POST -d "$2" "$target/$1" >&2
     curl -s -H "Content-Type: application/json" -X POST -d "$2" "$target/$1"
 }
 
@@ -101,7 +100,6 @@ check() {
 
 report() {
     matchGAV $1
-    echo `formatGAVjson`
     tmpfile=`mktemp`
     echo "[" > $tmpfile # WA until there is pretty print for reports
     post "reports/gav" "`formatGAVjson`" >> $tmpfile

--- a/cli/listings.sh
+++ b/cli/listings.sh
@@ -13,7 +13,7 @@ setColor() {
     esac
 }
 
-pretyprintGAV() {
+prettyPrintGAV() {
     python -m json.tool | \
         egrep '"(artifactId|groupId|version)"' | \
         sed -r 's/ *"groupId": "([^"]*)",?/g:\1\t/;
@@ -53,7 +53,7 @@ formatGAVjson() {
 
 list() {
     setColor $1
-    get "listings/${color}list" | pretyprintGAV
+    get "listings/${color}list" | prettyPrintGAV
 }
 
 deleteGAVFromList() {

--- a/cli/pretty-lookup.py
+++ b/cli/pretty-lookup.py
@@ -3,15 +3,13 @@ import json
 import sys
 import fileinput
 
-data=""
-#for line in sys.stdin:
-for line in fileinput.input():
-    data += line
 
-jdata = json.loads(data)
-
-for e in jdata:
+def read_json_object(e):
     lists="no list"
+    if "message" in e:
+        # message key present when there is an error
+        print(e["message"])
+        sys.exit(1)
     if e["blacklisted"] and e["whitelisted"]:
         lists="both lists"
     elif e["blacklisted"]:
@@ -24,4 +22,20 @@ for e in jdata:
     else:
         prettyAvailableVersions = ""
 
-    print e["groupId"]+":"+e["artifactId"]+":"+e["version"]+"\t"+str(e["bestMatchVersion"]) + prettyAvailableVersions + "\t"+lists
+    print(e["groupId"]+":"+e["artifactId"]+":"+e["version"]+"\t"+str(e["bestMatchVersion"]) + prettyAvailableVersions + "\t"+lists)
+
+
+data=""
+for line in fileinput.input():
+    data += line
+
+jdata = json.loads(data)
+
+if type(jdata) is dict:
+    read_json_object(jdata)
+
+elif type(jdata) is list:
+    for e in jdata:
+        read_json_object(e)
+else:
+    print("Couldn't parse the JSON data: " + data)


### PR DESCRIPTION
1. Rename `pom` option to `pom-bw` for `da-cli.sh` and `da-cli-admin.sh`
2. Add the `pom-report` option
3. Make `pretty-lookup.py` accept either a JSON list or a JSON object
   The JSON object is returned for the `/reports/gav` endpoint, and the
   JSON list returned for the `/reports/lookup` endpoint. As such, this
   commit removes the '[' and ']' surrounding the JSON received in the
   `report` function in `listings.sh`, since `pretty-lookup.py` can now
   parse a JSON object too.

4. Make `pretty-lookup.py` search for the `message` key, which indicates
   that something went wrong. If the `message` key is found,
   print the `message` value and exit.

   Note: this assumption is weak and should be improved in the future.
   Note2: this change is required to properly handle the new response code
               in the endpoints.

5. Add parantheses to the `print` function in `pretty-lookup.py` to make
   it work with Python3.

Note: I'm not too happy with the `pom-report` option output, but it works for now. The output is the same as `da-cli.sh report gId:aId:ver`