### PR TITLE
[DA-98][DA-101] CLI changes

### DIFF
--- a/cli/da-cli-admin.sh
+++ b/cli/da-cli-admin.sh
@@ -19,10 +19,10 @@ printUsage() {
     echo "$0 list (b[lack]|w[hite])"
     echo "    List all artifacts in black or white list"
     echo ""
-    echo "$0 pom-bw [--transitive]";
+    echo "$0 pom-bw [--transitive] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status"
     echo ""
-    echo "$0 pom-report [--transitive]";
+    echo "$0 pom-report [--transitive] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status"
     echo "    Output: <groupId>:<artifactId>:<version> :: <groupId>:<artifactId>:<version> <Best Matched Red Hat Version> <Available Versions> <In black/white list?>"
     echo ""
@@ -48,8 +48,8 @@ case $action in
     delete) deleteGAVFromList $2 $3;;
     check) check $2 $3;;
     list) list $2;;
-    pom-bw) pom_bw $2;;
-    pom-report) pom_report $2;;
+    pom-bw) pom_bw $2 $3;;
+    pom-report) pom_report $2 $3;;
     lookup) lookup;;
     report) report $2;;
     *) printUsage ;;

--- a/cli/da-cli-admin.sh
+++ b/cli/da-cli-admin.sh
@@ -19,10 +19,10 @@ printUsage() {
     echo "$0 list (b[lack]|w[hite])"
     echo "    List all artifacts in black or white list"
     echo ""
-    echo "$0 pom-bw [--no-transitive]";
+    echo "$0 pom-bw [--transitive]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status"
     echo ""
-    echo "$0 pom-report [--no-transitive]";
+    echo "$0 pom-report [--transitive]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status"
     echo "    Output: <groupId>:<artifactId>:<version> :: <groupId>:<artifactId>:<version> <Best Matched Red Hat Version> <Available Versions> <In black/white list?>"
     echo ""

--- a/cli/da-cli.sh
+++ b/cli/da-cli.sh
@@ -13,10 +13,10 @@ printUsage() {
     echo "$0 list (b[lack]|w[hite])"
     echo "    List all artifacts in black or white list"
     echo ""
-    echo "$0 pom-bw [--transitive]";
+    echo "$0 pom-bw [--transitive] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status"
     echo ""
-    echo "$0 pom-report [--transitive]";
+    echo "$0 pom-report [--transitive] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status"
     echo "    Output: <groupId>:<artifactId>:<version> :: <groupId>:<artifactId>:<version> <Best Matched Red Hat Version> <Available Versions> <In black/white list?>"
     echo ""
@@ -40,8 +40,8 @@ action=$1
 case $action in
     check) check $2 $3;;
     list) list $2;;
-    pom-bw) pom_bw $2;;
-    pom-report) pom_report $2;;
+    pom-bw) pom_bw $2 $3;;
+    pom-report) pom_report $2 $3;;
     lookup) lookup;;
     report) report $2;;
     *) printUsage ;;

--- a/cli/da-cli.sh
+++ b/cli/da-cli.sh
@@ -13,10 +13,10 @@ printUsage() {
     echo "$0 list (b[lack]|w[hite])"
     echo "    List all artifacts in black or white list"
     echo ""
-    echo "$0 pom-bw [--no-transitive]";
+    echo "$0 pom-bw [--transitive]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status"
     echo ""
-    echo "$0 pom-report [--no-transitive]";
+    echo "$0 pom-report [--transitive]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status"
     echo "    Output: <groupId>:<artifactId>:<version> :: <groupId>:<artifactId>:<version> <Best Matched Red Hat Version> <Available Versions> <In black/white list?>"
     echo ""

--- a/cli/listings.sh
+++ b/cli/listings.sh
@@ -124,7 +124,9 @@ lookup() {
 
 pom_bw() {
     mvn_opts=""
-    if [ "x$1" = "x--no-transitive" ]; then
+    if [ "x$1" = "x--transitive" ]; then
+        mvn_opts="$mvn_opts"
+    else
         mvn_opts="$mvn_opts -DexcludeTransitive=true"
     fi
 
@@ -178,7 +180,9 @@ pom_bw() {
 
 pom_report() {
     mvn_opts=""
-    if [ "x$1" = "x--no-transitive" ]; then
+    if [ "x$1" = "x--transitive" ]; then
+        mvn_opts="$mvn_opts"
+    else
         mvn_opts="$mvn_opts -DexcludeTransitive=true"
     fi
 


### PR DESCRIPTION
1. Change the `pom-report` and `pom-bw` default behaviour. Now it'll only show top-level dependencies. The user can optionally select to show transitive dependencies by using the `--transitive` flag. (DA-98)
2. User can now optionally specify the directory to where the `pom.xml` to be analyzed is located for `pom-report` and `pom-bw`. (DA-101)