### PR TITLE
[DA-65] Implement create build configuration from PNC

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
@@ -2,6 +2,7 @@ package org.jboss.da.communication.pnc.api;
 
 import java.util.List;
 import org.jboss.da.communication.pnc.model.BuildConfiguration;
+import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
 import org.jboss.da.communication.pnc.model.BuildConfigurationSet;
 import org.jboss.da.communication.pnc.model.Product;
 import org.jboss.da.communication.pnc.model.Project;
@@ -15,6 +16,8 @@ public interface PNCConnector {
     List<BuildConfigurationSet> getBuildConfigurationSets() throws Exception;
 
     List<BuildConfiguration> getBuildConfigurations() throws Exception;
+
+    BuildConfiguration createBuildConfiguration(BuildConfigurationCreate bc) throws Exception;
 
     List<Product> getProducts() throws Exception;
 

--- a/communication/src/main/java/org/jboss/da/communication/pnc/impl/PNCConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/impl/PNCConnectorImpl.java
@@ -5,6 +5,7 @@ import org.jboss.da.common.util.Configuration;
 import org.jboss.da.common.util.ConfigurationParseException;
 import org.jboss.da.communication.pnc.authentication.PNCAuthentication;
 import org.jboss.da.communication.pnc.model.BuildConfiguration;
+import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
 import org.jboss.da.communication.pnc.model.BuildConfigurationSet;
 import org.jboss.da.communication.pnc.model.Product;
 import org.jboss.da.communication.pnc.model.Project;
@@ -26,7 +27,7 @@ public class PNCConnectorImpl implements PNCConnector {
     @Inject
     private PNCAuthentication pncAuthenticate;
 
-    public ClientRequest getClient(String endpoint, boolean authenticate)
+    private ClientRequest getClient(String endpoint, boolean authenticate)
             throws ConfigurationParseException {
         ClientRequest request = new ClientRequest(config.getConfig().getPncServer()
                 + "/pnc-rest/rest/" + endpoint);
@@ -46,11 +47,23 @@ public class PNCConnectorImpl implements PNCConnector {
         return getClient(endpoint, false);
     }
 
+    public ClientRequest getAuthenticatedClient(String endpoint) throws ConfigurationParseException {
+        return getClient(endpoint, true);
+    }
+
     @Override
     public List<BuildConfiguration> getBuildConfigurations() throws Exception {
         ClientResponse<BuildConfiguration[]> response = getClient("build-configurations").get(
                 BuildConfiguration[].class);
         return Arrays.asList(response.getEntity());
+    }
+
+    @Override
+    public BuildConfiguration createBuildConfiguration(BuildConfigurationCreate bc)
+            throws Exception {
+        ClientResponse<BuildConfiguration> response = getClient("build-configurations").body(
+                MediaType.APPLICATION_JSON, bc).post(BuildConfiguration.class);
+        return response.getEntity();
     }
 
     @Override

--- a/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfiguration.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfiguration.java
@@ -1,66 +1,11 @@
 package org.jboss.da.communication.pnc.model;
 
-import java.util.Date;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
-public class BuildConfiguration {
+public class BuildConfiguration extends BuildConfigurationCreate {
 
     @Getter
     @Setter
     private int id;
-
-    @Getter
-    @Setter
-    private String name;
-
-    @Getter
-    @Setter
-    private String description;
-
-    @Getter
-    @Setter
-    private String buildScript;
-
-    @Getter
-    @Setter
-    private String scmRepoURL;
-
-    @Getter
-    @Setter
-    private String scmRevision;
-
-    @Getter
-    @Setter
-    private Date creationTime;
-
-    @Getter
-    @Setter
-    private Date lastModificationTime;
-
-    @Getter
-    @Setter
-    private String buildStatus;
-
-    @Getter
-    @Setter
-    private String repositories;
-
-    @Getter
-    @Setter
-    private int projectId;
-
-    @Getter
-    @Setter
-    private int environmentId;
-
-    @Getter
-    @Setter
-    private List<Integer> dependencyIds;
-
-    @Getter
-    @Setter
-    private List<Integer> productVersionIds;
-
 }

--- a/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfigurationCreate.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfigurationCreate.java
@@ -1,0 +1,66 @@
+package org.jboss.da.communication.pnc.model;
+
+import java.util.Date;
+import java.util.List;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+public class BuildConfigurationCreate {
+
+    @Getter
+    @Setter
+    @NonNull
+    private String name;
+
+    @Getter
+    @Setter
+    private String description;
+
+    @Getter
+    @Setter
+    private String buildScript;
+
+    @Getter
+    @Setter
+    private String scmRepoURL;
+
+    @Getter
+    @Setter
+    private String scmRevision;
+
+    @Getter
+    @Setter
+    private Date creationTime;
+
+    @Getter
+    @Setter
+    private Date lastModificationTime;
+
+    @Getter
+    @Setter
+    private String buildStatus;
+
+    @Getter
+    @Setter
+    private String repositories;
+
+    @Getter
+    @Setter
+    @NonNull
+    private int projectId;
+
+    @Getter
+    @Setter
+    @NonNull
+    private int environmentId;
+
+    @Getter
+    @Setter
+    private List<Integer> dependencyIds;
+
+    @Getter
+    @Setter
+    private List<Integer> productVersionIds;
+
+}

--- a/communication/src/test/java/org/jboss/da/communication/PNCConnectorImplTest.java
+++ b/communication/src/test/java/org/jboss/da/communication/PNCConnectorImplTest.java
@@ -52,22 +52,19 @@ public class PNCConnectorImplTest {
 
         ClientRequest req = pncConnectorImpl.getClient("matin");
         assertEquals(req.getUri(), "http://test.me/pnc-rest/rest/matin");
-
-        ClientRequest reqExplicitNotAuthenticated = pncConnectorImpl.getClient("soir", false);
-        assertEquals(reqExplicitNotAuthenticated.getUri(), "http://test.me/pnc-rest/rest/soir");
     }
 
     @Test
     public void shouldGenerateRightUriBasedOnPncServerAndEndpointAuthenticated() throws Exception {
 
-        ClientRequest req = pncConnectorImpl.getClient("gabriella", true);
+        ClientRequest req = pncConnectorImpl.getAuthenticatedClient("gabriella");
         assertEquals(req.getUri(), "http://test.me/pnc-rest/rest/gabriella");
     }
 
     @Test
     public void shouldAddAuthenticationTokenToHeaderForAuthenticatedEndpoint() throws Exception {
 
-        ClientRequest req = pncConnectorImpl.getClient("testme", true);
+        ClientRequest req = pncConnectorImpl.getAuthenticatedClient("testme");
 
         MultivaluedMap<String, String> headers = req.getHeaders();
         assertTrue(headers.containsKey("Authorization"));


### PR DESCRIPTION
Add 'Create Build Configuration' functionality to PNCConnector class.

When POSTing data about a new Build Configuration to PNC, the latter
requires us to not specify the id. As such, the `BuildConfiguration`
class was refactored so that `BuildConfigurationCreate` has all the
fields that in a BuildConfiguration minus the id.

`BuildConfiguration` then extends `BuildConfigurationCreate` and adds
the `id` field.

The three required fields for `BuildConfigurationCreate` for the
creation of Build Configurations to succeed are:

- name
- projectId
- environmentId

These three fields are annotated as `@NonNull`.