### PR TITLE
[DA-107] Change datastore to PostgreSQL

### DIFF
--- a/application/src/main/application/META-INF/persistence.xml
+++ b/application/src/main/application/META-INF/persistence.xml
@@ -4,12 +4,12 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
     <persistence-unit name="relationdbPU">
         <provider>org.hibernate.ejb.HibernatePersistence</provider>
-        <jta-data-source>java:jboss/datasources/MysqlDA</jta-data-source>
+        <jta-data-source>java:jboss/datasources/PostgresDA</jta-data-source>
         <class>org.jboss.da.listings.api.model.WhiteArtifact</class>
         <class>org.jboss.da.listings.api.model.BlackArtifact</class>
         <properties>
             <property name="org.hibernate.FlushMode" value="always" />
-            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect" />
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQL82Dialect" />
             <property name="hibernate.hbm2ddl.auto" value="update" />
             <property name="hibernate.show_sql" value="false" />
             <property name="hibernate.format_sql" value="false" />


### PR DESCRIPTION
Changes required in JBoss EAP 6.4:

1. Create a new PostgreSQL database called `da`

```bash
createdb da
```

2. In `jboss-eap-6.4/standalone/configuration/standalone.xml`:

- Add a new datasource:

```xml
<datasource jndi-name="java:jboss/datasources/PostgresDA" pool-name="PostgresDA" enabled="true">
    <connection-url>jdbc:postgresql://localhost:5432/da</connection-url>
    <driver>postgresql-jdbc4</driver>
    <security>
        <user-name>sa</user-name>
        <password>sa</password>
    </security>
</datasource>
```

Please change the username and password to something more appropriate.

- Add the JDBC PostgreSQL driver definition:

```xml
<driver name="postgresql-jdbc4" module="org.postgresql">
    <driver-class>org.postgresql.Driver</driver-class>
</driver>
```

3. In `<EAP_HOME>/modules/system/layers/base/org/postgresql/main`:
- Download the postgresql JDBC driver (https://jdbc.postgresql.org/download/postgresql-9.4-1201.jdbc4.jar) and place it in the folder.

- Add a file named `module.xml` with content:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<module xmlns="urn:jboss:module:1.0" name="org.postgresql">
        <resources>
                <resource-root path="postgresql-9.4-1201.jdbc4.jar"/>
        </resources>
        <dependencies><module name="javax.api"/></dependencies>
</module>
```