### PR TITLE
REST fixes

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,8 +10,8 @@
     <packaging>ejb</packaging>
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
         </dependency>
 
         <dependency>

--- a/common/src/main/java/org/jboss/da/common/util/Configuration.java
+++ b/common/src/main/java/org/jboss/da/common/util/Configuration.java
@@ -2,7 +2,7 @@ package org.jboss.da.common.util;
 
 import java.io.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.jboss.da.common.json.DAConfig;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/communication/pom.xml
+++ b/communication/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
+            <artifactId>jackson-mapper-asl</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/communication/src/test/java/org/jboss/da/communication/model/GAVIntegrationTest.java
+++ b/communication/src/test/java/org/jboss/da/communication/model/GAVIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jboss.da.communication.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -22,9 +22,8 @@ public class GAVIntegrationTest {
 
         String json = convertToJson(gav);
 
-        String expectedJson = "{\"ga\":{\"groupId\":\"" + groupId + "\",\"artifactId\":\""
-                + artifactId + "\"},\"version\":\"" + version + "\",\"groupId\":\"" + groupId
-                + "\",\"artifactId\":\"" + artifactId + "\"}";
+        String expectedJson = "{\"groupId\":\"" + groupId + "\",\"artifactId\":\"" + artifactId
+                + "\",\"version\":\"" + version + "\"}";
         assertEquals(expectedJson, json);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -136,13 +136,8 @@
                 <version>1.2</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.4.4</version>
-            </dependency>
-            <dependency>
                 <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-core-asl</artifactId>
+                <artifactId>jackson-mapper-asl</artifactId>
                 <version>1.9.9</version>
             </dependency>
             <dependency>

--- a/reports-rest/pom.xml
+++ b/reports-rest/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
+            <artifactId>jackson-mapper-asl</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -117,14 +117,15 @@ public class Reports {
                     value = "JSON list of objects with keys 'groupId', 'artifactId', and 'version'") List<GAV> gavRequest) {
 
         List<LookupReport> reportsList = new ArrayList<>();
-        Status responseStatus = Status.OK;
+        int responseStatus = Status.OK.getStatusCode();
         for (GAV gav : gavRequest) {
             try {
                 VersionLookupResult lookupResult = versionFinder.lookupBuiltVersions(gav);
                 LookupReport lookupReport = toLookupReport(gav, lookupResult);
                 reportsList.add(lookupReport);
                 if (lookupResult == null) {
-                    responseStatus = Status.PARTIAL_CONTENT;
+                    // Don't use Status.PARTIAL_CONTENT since it's not available in EAP 6.4
+                    responseStatus = 206;
                 }
             } catch (CommunicationException ex) {
                 log.error("Communication with remote repository failed", ex);

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/model/LookupReport.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/model/LookupReport.java
@@ -1,6 +1,6 @@
 package org.jboss.da.rest.reports.model;
 
-import org.codehaus.jackson.annotate.JsonUnwrapped;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.jboss.da.communication.model.GAV;
 
 import javax.xml.bind.annotation.XmlTransient;
@@ -15,10 +15,15 @@ import lombok.Setter;
 @AllArgsConstructor
 public class LookupReport {
 
+    /*
+     * Manually unwrap 'gav' via getters so as not to confuse Swagger.
+     * 
+     * Also, use @JsonIgnore so that the getters and setters generated for 'gav' are also ignored by Jackson.
+     */
     @Getter
     @Setter
     @NonNull
-    @JsonUnwrapped
+    @JsonIgnore
     @XmlTransient
     private GAV gav;
 
@@ -38,6 +43,10 @@ public class LookupReport {
     @Setter
     private boolean whitelisted;
 
+    // **************************************************************************
+    // Keep `getGroupId`, `getArtifactId`, and `getVersion` here for Swagger,
+    // and so that Jackson knows how to marshall 'gav' properly!
+    // **************************************************************************
     public String getGroupId() {
         return gav.getGroupId();
     }


### PR DESCRIPTION
Fixes: 
- DA-117: pom.xml has dependencies on jackson deps with different versions
- DA-118: /lookup/gav endpoint has duplicate groupid, artifactId, and version fields in the JSON reply

- Use '206' for partial content instead of `Status.PARTIAL_CONTENT` since `Status.PARTIAL_CONTENT` is not defined in EAP 6.4.
