### PR TITLE
[DA-119] Rename /lookup/gav endpoint to /lookup/gavs

### DIFF
--- a/cli/listings.sh
+++ b/cli/listings.sh
@@ -117,7 +117,7 @@ lookup() {
     done
     query="$query ]"
     tmpfile=`mktemp`
-    curl -s -H "Content-Type: application/json" -X POST -d "$query" "$target/reports/lookup/gav" > $tmpfile
+    curl -s -H "Content-Type: application/json" -X POST -d "$query" "$target/reports/lookup/gavs" > $tmpfile
     cat $tmpfile | $basedir/pretty-lookup.py
     rm $tmpfile
 }

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -99,7 +99,7 @@ public class Reports {
     }
 
     @POST
-    @Path("/lookup/gav")
+    @Path("/lookup/gavs")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Lookup built versions for the list of provided GAVs",


### PR DESCRIPTION
Since the '/lookup/gav' endpoint accepts several 'gavs', the endpoint
name should be changed to '/lookup/gavs' to reflect that it can accept
several 'gavs'.

Thanks to Nick Cross (@rnc) for proposing that idea!