### PR TITLE
Get rid of null and NoGAVInRepositoryException

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/NoGAVInRepositoryException.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/NoGAVInRepositoryException.java
@@ -1,8 +1,0 @@
-package org.jboss.da.communication.aprox;
-
-public class NoGAVInRepositoryException extends Exception {
-
-    public NoGAVInRepositoryException(String message) {
-        super(message);
-    }
-}

--- a/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
@@ -1,12 +1,12 @@
 package org.jboss.da.communication.aprox.api;
 
 import org.jboss.da.communication.CommunicationException;
-import org.jboss.da.communication.aprox.NoGAVInRepositoryException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GA;
 import org.jboss.da.communication.model.GAV;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AproxConnector {
 
@@ -16,27 +16,27 @@ public interface AproxConnector {
      * @param scmUrl
      * @param revision
      * @param pomPath
-     * @return dependency tree of revision
+     * @return Optional of dependency tree of revision
      * @throws CommunicationException When there is problem with communication.
      */
-    GAVDependencyTree getDependencyTreeOfRevision(String scmUrl, String revision, String pomPath)
-            throws CommunicationException;
+    Optional<GAVDependencyTree> getDependencyTreeOfRevision(String scmUrl, String revision,
+            String pomPath) throws CommunicationException;
 
     /**
      * Finds dependency trees of specific GAV
      * 
      * @param gav
-     * @return dependency tree of GAV
+     * @return Optional of dependency tree of GAV
      * @throws CommunicationException When there is problem with communication.
      */
-    GAVDependencyTree getDependencyTreeOfGAV(GAV gav) throws CommunicationException,
-            NoGAVInRepositoryException;
+    Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav) throws CommunicationException;
 
     /**
-     * Finds available versions of specific groupId artifactId
+     * Finds available versions of specific groupId artifactId.
+     * If the provided groupId artifactId is not found in repository, returns empty list.
      * 
      * @param ga
-     * @return list of versions or null when the groupId artifactId is not found
+     * @return list of versions for given groupId artifactId in repository.
      * @throws CommunicationException When there is problem with communication.
      */
     List<String> getVersionsOfGA(GA ga) throws CommunicationException;

--- a/reports-backend/src/main/java/org/jboss/da/reports/api/ArtifactReport.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/ArtifactReport.java
@@ -7,6 +7,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import lombok.Getter;
@@ -31,7 +32,8 @@ public class ArtifactReport {
     private final Set<String> availableVersions = new HashSet<>();
 
     @Getter
-    private String bestMatchVersion;
+    @NonNull
+    private Optional<String> bestMatchVersion = Optional.empty();
 
     @NonNull
     private final Set<ArtifactReport> dependencies = new HashSet<>();
@@ -50,9 +52,9 @@ public class ArtifactReport {
     @Setter
     private boolean whiteListed;
 
-    public void setBestMatchVersion(String version) {
-        if (version != null) {
-            availableVersions.add(version);
+    public void setBestMatchVersion(Optional<String> version) {
+        if (version.isPresent()) {
+            availableVersions.add(version.get());
         }
         bestMatchVersion = version;
     }
@@ -94,7 +96,7 @@ public class ArtifactReport {
      * @return true if this artifact and all the dependencies of this artifact have a GAV already in PNC/Brew.
      */
     public boolean isDependencyVersionSatisfied() {
-        if (bestMatchVersion == null) {
+        if (!bestMatchVersion.isPresent()) {
             return false;
         }
         return dependencies.stream().noneMatch((dependency) -> (!dependency.isDependencyVersionSatisfied()));
@@ -103,7 +105,7 @@ public class ArtifactReport {
     public int getNotBuiltDependencies() {
         return dependencies.stream().mapToInt((dependency) -> {
             int number = dependency.getNotBuiltDependencies();
-            if(dependency.bestMatchVersion == null){
+            if(!dependency.bestMatchVersion.isPresent()){
                 number ++;
             }
             return number;

--- a/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
@@ -1,9 +1,9 @@
 package org.jboss.da.reports.api;
 
+import java.util.List;
+import java.util.Optional;
 import org.jboss.da.communication.CommunicationException;
 import org.jboss.da.communication.model.GAV;
-
-import java.util.List;
 
 /**
  *
@@ -12,9 +12,9 @@ import java.util.List;
  */
 public interface ReportsGenerator {
 
-    public ArtifactReport getReport(SCMLocator scml, List<Product> products);
+    public Optional<ArtifactReport> getReport(SCMLocator scml, List<Product> products);
 
-    public ArtifactReport getReport(GAV gav, List<Product> products);
+    public Optional<ArtifactReport> getReport(GAV gav, List<Product> products);
 
     /**
      * Creates a report about built/not built/blacklisted artifacts. It performs searches
@@ -22,9 +22,9 @@ public interface ReportsGenerator {
      * certain product are applied.
      *
      * @param gav Top-level GAV for which is the report generated
-     * @return Created report or null if the requested GAV was not found in the repository
+     * @return Created report or empty Optional if the requested GAV was not found in the repository
      * @throws CommunicationException when there is a problem with communication with remote services
      */
-    public ArtifactReport getReport(GAV gav) throws CommunicationException;
+    public Optional<ArtifactReport> getReport(GAV gav) throws CommunicationException;
 
 }

--- a/reports-backend/src/main/java/org/jboss/da/reports/api/VersionLookupResult.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/VersionLookupResult.java
@@ -1,6 +1,7 @@
 package org.jboss.da.reports.api;
 
 import java.util.List;
+import java.util.Optional;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,7 +18,7 @@ public class VersionLookupResult {
 
     @Getter
     @Setter
-    private String bestMatchVersion;
+    private Optional<String> bestMatchVersion;
 
     @Getter
     @Setter

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
@@ -1,5 +1,7 @@
 package org.jboss.da.reports.backend.api;
 
+import java.util.Optional;
+import org.jboss.da.communication.CommunicationException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.reports.api.SCMLocator;
@@ -10,8 +12,9 @@ import org.jboss.da.reports.api.SCMLocator;
  */
 public interface DependencyTreeGenerator {
 
-    public GAVDependencyTree getDependencyTree(SCMLocator scml);
+    public Optional<GAVDependencyTree> getDependencyTree(SCMLocator scml)
+            throws CommunicationException;
 
-    public GAVDependencyTree getDependencyTree(GAV gav);
+    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException;
 
 }

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/api/VersionFinder.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/api/VersionFinder.java
@@ -5,6 +5,7 @@ import org.jboss.da.communication.model.GAV;
 import org.jboss.da.reports.api.VersionLookupResult;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  *
@@ -17,7 +18,7 @@ public interface VersionFinder {
      * Finds all Red Hat built artifacts (with suffix -redhat) with the same GA
      * 
      * @param gav GroupId and ArtifactId, which specifies the artifact
-     * @return Found built Red Hat artifacts with the same GA or null if the GA was not found
+     * @return Found built Red Hat artifacts with the same GA
      * @throws CommunicationException when there is a problem with communication with remote services
      */
     List<String> getBuiltVersionsFor(GAV gav) throws CommunicationException;
@@ -27,29 +28,29 @@ public interface VersionFinder {
      * the best match built artifact to the requested GA
      * 
      * @param gav GroupId and ArtifactId, which specifies the artifact
-     * @return Found data about built artifacts or null if the GA was not found
+     * @return Found data about built artifacts
      * @throws CommunicationException when there is a problem with communication with remote services
      */
     VersionLookupResult lookupBuiltVersions(GAV gav) throws CommunicationException;
 
     /**
      * Tries to find the Red Hat built version of specified artifacts. Tries to find
-     * the latest built. If there is not built artifact with given GAV, null is returned.
+     * the latest built. If there is not built artifact with given GAV, empty Optional is returned.
      * 
      * @param gav GAV, which specifies the artifact
-     * @return Found biggest version of built artifact with given GAV or null if this artifact was not built yet
+     * @return Found biggest version of built artifact with given GAV or empty Optional if this artifact was not built yet
      * @throws CommunicationException when there is a problem with communication with remote services
      */
-    String getBestMatchVersionFor(GAV gav) throws CommunicationException;
+    Optional<String> getBestMatchVersionFor(GAV gav) throws CommunicationException;
 
     /**
      * Tries to find the Red Hat built version of specified artifacts in the provided list of available built versions of artifact.
-     * Tries to find the latest built. If there is not built artifact with given GAV, null is returned.
+     * Tries to find the latest built. If there is not built artifact with given GAV, empty Optional is returned.
      *
      * @param gav GAV, which specifies the artifact
      * @param availableVersions Available built versions of the specified artifact
-     * @return Found biggest version of built artifact with given GAV or null if this artifact was not built yet
+     * @return Found biggest version of built artifact with given GAV or empty Optional if this artifact was not built yet
      */
-    String getBestMatchVersionFor(GAV gav, List<String> availableVersions);
+    Optional<String> getBestMatchVersionFor(GAV gav, List<String> availableVersions);
 
 }

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -1,7 +1,7 @@
 package org.jboss.da.reports.backend.impl;
 
+import java.util.Optional;
 import org.jboss.da.communication.CommunicationException;
-import org.jboss.da.communication.aprox.NoGAVInRepositoryException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
@@ -23,21 +23,14 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     private AproxConnector aproxConnector;
 
     @Override
-    public GAVDependencyTree getDependencyTree(SCMLocator scml) {
-        try {
-            return aproxConnector.getDependencyTreeOfRevision(scml.getScmUrl(), scml.getRevision(),
-                    scml.getPomPath());
-        } catch (CommunicationException ex) {
-            throw new RuntimeException(ex);
-        }
+    public Optional<GAVDependencyTree> getDependencyTree(SCMLocator scml)
+            throws CommunicationException {
+        return aproxConnector.getDependencyTreeOfRevision(scml.getScmUrl(), scml.getRevision(),
+                scml.getPomPath());
     }
 
     @Override
-    public GAVDependencyTree getDependencyTree(GAV gav) {
-        try {
-            return aproxConnector.getDependencyTreeOfGAV(gav);
-        } catch (CommunicationException | NoGAVInRepositoryException ex) {
-            throw new RuntimeException(ex);
-        }
+    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException {
+        return aproxConnector.getDependencyTreeOfGAV(gav);
     }
 }

--- a/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
@@ -1,7 +1,6 @@
 package org.jboss.da.reports.impl;
 
 import org.jboss.da.communication.CommunicationException;
-import org.jboss.da.communication.aprox.NoGAVInRepositoryException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.reports.api.ArtifactReport;
@@ -12,13 +11,14 @@ import org.slf4j.Logger;
 
 import javax.inject.Inject;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.listings.api.service.BlackArtifactService;
 import org.jboss.da.listings.api.service.WhiteArtifactService;
+import org.jboss.da.reports.api.VersionLookupResult;
 import org.jboss.da.reports.backend.api.VersionFinder;
 
 /**
@@ -47,36 +47,36 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
     private WhiteArtifactService whiteArtifactService;
 
     @Override
-    public ArtifactReport getReport(SCMLocator scml, List<Product> products) {
+    public Optional<ArtifactReport> getReport(SCMLocator scml, List<Product> products) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public ArtifactReport getReport(GAV gav, List<Product> products) {
+    public Optional<ArtifactReport> getReport(GAV gav, List<Product> products) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public ArtifactReport getReport(GAV gav) throws CommunicationException {
+    public Optional<ArtifactReport> getReport(GAV gav) throws CommunicationException {
         if (gav == null)
             throw new IllegalArgumentException("GAV can't be null");
-        List<String> versions = versionFinderImpl.getBuiltVersionsFor(gav);
-        if (versions == null)
-            versions = Collections.emptyList();
-        ArtifactReport ar = toArtifactReport(gav, versions);
-        try {
-            GAVDependencyTree dt = aproxClient.getDependencyTreeOfGAV(gav);
-            addDependencyReports(ar, dt.getDependencies());
-            return ar;
-        } catch (NoGAVInRepositoryException e) {
-            return null;
-        }
+
+        Optional<GAVDependencyTree> dt = aproxClient.getDependencyTreeOfGAV(gav);
+        if (!dt.isPresent())
+            return Optional.empty();
+
+        VersionLookupResult result = versionFinderImpl.lookupBuiltVersions(gav);
+        ArtifactReport report = toArtifactReport(gav, result);
+
+        addDependencyReports(report, dt.get().getDependencies());
+
+        return Optional.of(report);
     }
 
-    private ArtifactReport toArtifactReport(GAV gav, List<String> availableVersions) {
+    private ArtifactReport toArtifactReport(GAV gav, VersionLookupResult result) {
         ArtifactReport report = new ArtifactReport(gav);
-        report.addAvailableVersions(availableVersions);
-        report.setBestMatchVersion(versionFinderImpl.getBestMatchVersionFor(gav, availableVersions));
+        report.addAvailableVersions(result.getAvailableVersions());
+        report.setBestMatchVersion(result.getBestMatchVersion());
         report.setBlacklisted(blackArtifactService.isArtifactPresent(gav));
         report.setWhiteListed(whiteArtifactService.isArtifactPresent(gav));
         return report;
@@ -85,14 +85,9 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
     private void addDependencyReports(ArtifactReport ar, Set<GAVDependencyTree> dependencyTree)
             throws CommunicationException {
         for (GAVDependencyTree dt : dependencyTree) {
-            List<String> versions = versionFinderImpl.getBuiltVersionsFor(dt.getGav());
+            VersionLookupResult result = versionFinderImpl.lookupBuiltVersions(dt.getGav());
 
-            if (versions == null) {
-                log.warn("Versions for dependency {} was not found", dt.getGav());
-                versions = Collections.emptyList();
-            }
-
-            ArtifactReport dar = toArtifactReport(dt.getGav(), versions);
+            ArtifactReport dar = toArtifactReport(dt.getGav(), result);
             addDependencyReports(dar, dt.getDependencies());
             ar.addDependency(dar);
         }

--- a/reports-backend/src/test/java/org/jboss/da/reports/api/ArtifactReportTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/api/ArtifactReportTest.java
@@ -1,5 +1,6 @@
 package org.jboss.da.reports.api;
 
+import java.util.Optional;
 import org.jboss.da.communication.model.GAV;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
@@ -25,7 +26,7 @@ public class ArtifactReportTest {
         assertEquals(1, ar.getNotBuiltDependencies());
 
         ArtifactReport ar2 = new ArtifactReport(new GAV("otg.example", "dep2", "0.1"));
-        ar2.setBestMatchVersion("0.1.0.redhat-2");
+        ar2.setBestMatchVersion(Optional.of("0.1.0.redhat-2"));
         ar.addDependency(ar2);
 
         assertEquals(1, ar.getNotBuiltDependencies());
@@ -36,7 +37,7 @@ public class ArtifactReportTest {
         assertEquals(2, ar.getNotBuiltDependencies());
 
         ArtifactReport ar12 = new ArtifactReport(new GAV("otg.example", "dep12", "0.1"));
-        ar12.setBestMatchVersion("0.1.0.redhat-2");
+        ar12.setBestMatchVersion(Optional.of("0.1.0.redhat-2"));
         ar12.addDependency(ar12);
 
         assertEquals(2, ar.getNotBuiltDependencies());

--- a/reports-backend/src/test/java/org/jboss/da/reports/backend/impl/VersionFinderTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/backend/impl/VersionFinderTest.java
@@ -17,7 +17,9 @@ import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 
@@ -106,9 +108,10 @@ public class VersionFinderTest {
 
     @Test
     public void lookupBuiltVersionsNonExistingGAVTest() throws CommunicationException {
-        prepare(null);
+        prepare(Collections.EMPTY_LIST);
         VersionLookupResult lookupResult = versionFinder.lookupBuiltVersions(SOME_GAV);
-        assertNull(lookupResult);
+        assertTrue(lookupResult.getAvailableVersions().isEmpty());
+        assertFalse(lookupResult.getBestMatchVersion().isPresent());
     }
 
     @Test
@@ -116,16 +119,16 @@ public class VersionFinderTest {
         prepare(All_VERSIONS);
         VersionLookupResult lookupResult = versionFinder.lookupBuiltVersions(BUILT_GAV);
         assertNotNull(lookupResult);
-        assertEquals(BUILT_VERSION_RH, lookupResult.getBestMatchVersion());
+        assertEquals(BUILT_VERSION_RH, lookupResult.getBestMatchVersion().get());
         assertEquals(BUILT_VERSIONS.size(), lookupResult.getAvailableVersions().size());
         assertTrue(lookupResult.getAvailableVersions().containsAll(BUILT_VERSIONS));
     }
 
     @Test
     public void testVersionsForNonExistingGAV() throws CommunicationException {
-        prepare(null);
+        prepare(Collections.EMPTY_LIST);
         List<String> versions = versionFinder.getBuiltVersionsFor(SOME_GAV);
-        assertNull(versions);
+        assertTrue(versions.isEmpty());
     }
 
     @Test
@@ -144,16 +147,16 @@ public class VersionFinderTest {
 
     @Test
     public void getBestMatchVersionForNonExistingGAV() throws CommunicationException {
-        prepare(null);
-        String bmv = versionFinder.getBestMatchVersionFor(SOME_GAV);
-        assertNull(bmv);
+        prepare(Collections.EMPTY_LIST);
+        Optional<String> bmv = versionFinder.getBestMatchVersionFor(SOME_GAV);
+        assertFalse(bmv.isPresent());
     }
 
     @Test
     public void getBestMatchVersionForNotBuiltGAV() throws CommunicationException {
         prepare(All_VERSIONS);
-        String bmv = versionFinder.getBestMatchVersionFor(NO_BUILT_GAV);
-        assertNull(bmv);
+        Optional<String> bmv = versionFinder.getBestMatchVersionFor(NO_BUILT_GAV);
+        assertFalse(bmv.isPresent());
     }
 
     @Test
@@ -161,11 +164,11 @@ public class VersionFinderTest {
         String bmv;
         prepare(All_VERSIONS);
 
-        bmv = versionFinder.getBestMatchVersionFor(BUILT_GAV);
+        bmv = versionFinder.getBestMatchVersionFor(BUILT_GAV).get();
         assertNotNull(bmv);
         assertEquals(BUILT_VERSION_RH, bmv);
 
-        bmv = versionFinder.getBestMatchVersionFor(BUILT_GAV_2);
+        bmv = versionFinder.getBestMatchVersionFor(BUILT_GAV_2).get();
         assertNotNull(bmv);
         assertEquals(BUILT_VERSION_2_RH, bmv);
     }
@@ -173,7 +176,7 @@ public class VersionFinderTest {
     @Test
     public void getBestMatchVersionForMultipleBuiltGAV() throws CommunicationException {
         prepare(All_VERSIONS);
-        String bmv = versionFinder.getBestMatchVersionFor(MULTI_BUILT_GAV);
+        String bmv = versionFinder.getBestMatchVersionFor(MULTI_BUILT_GAV).get();
         assertNotNull(bmv);
         assertEquals(MULTI_BUILT_VERSION_RH_BEST, bmv);
     }
@@ -183,11 +186,11 @@ public class VersionFinderTest {
         String bmv;
         prepare(All_VERSIONS);
 
-        bmv = versionFinder.getBestMatchVersionFor(NON_OSGI_GAV);
+        bmv = versionFinder.getBestMatchVersionFor(NON_OSGI_GAV).get();
         assertNotNull(bmv);
         assertEquals(NON_OSGI_VERSION_RHT, bmv);
 
-        bmv = versionFinder.getBestMatchVersionFor(NON_OSGI_GAV_2);
+        bmv = versionFinder.getBestMatchVersionFor(NON_OSGI_GAV_2).get();
         assertNotNull(bmv);
         assertEquals(NON_OSGI_VERSION_2_RHT, bmv);
     }

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -1,7 +1,6 @@
 package org.jboss.da.reports.impl;
 
 import org.jboss.da.communication.CommunicationException;
-import org.jboss.da.communication.aprox.NoGAVInRepositoryException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
@@ -18,7 +17,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import org.jboss.da.reports.api.VersionLookupResult;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -77,34 +78,44 @@ public class ReportsGeneratorImplTest {
     private final GAVDependencyTree daCoreDT = new GAVDependencyTree(daCoreGAV, new HashSet<>(
             Arrays.asList(daUtilDT, daCommonDT)));
 
-    private static final String NO_BEST_MATCH_VERSION = null;
-
     private void prepare(boolean whitelisted, boolean blacklisted, List<String> versions,
-            String best, GAVDependencyTree dependencyTree) throws CommunicationException,
-            NoGAVInRepositoryException {
+            String best, GAVDependencyTree dependencyTree) throws CommunicationException {
         when(versionFinderImpl.getBuiltVersionsFor(daCoreGAV)).thenReturn(versions);
-        when(versionFinderImpl.getBestMatchVersionFor(daCoreGAV)).thenReturn(best);
-        when(versionFinderImpl.getBestMatchVersionFor(daCoreGAV, versions)).thenReturn(best);
+        when(versionFinderImpl.lookupBuiltVersions(daCoreGAV)).thenReturn(
+                new VersionLookupResult(Optional.ofNullable(best), versions));
+        when(versionFinderImpl.getBestMatchVersionFor(daCoreGAV)).thenReturn(
+                Optional.ofNullable(best));
+        when(versionFinderImpl.getBestMatchVersionFor(daCoreGAV, versions)).thenReturn(
+                Optional.ofNullable(best));
         when(blackArtifactService.isArtifactPresent(daCoreGAV)).thenReturn(blacklisted);
         when(whiteArtifactService.isArtifactPresent(daCoreGAV)).thenReturn(whitelisted);
-        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(dependencyTree);
+        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(
+                Optional.ofNullable(dependencyTree));
     }
 
-    private void prepareMulti() throws CommunicationException, NoGAVInRepositoryException {
+    private void prepareMulti() throws CommunicationException {
         prepare(false, false, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
-        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(daCoreDT);
+        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(
+                Optional.ofNullable(daCoreDT));
 
         when(versionFinderImpl.getBuiltVersionsFor(daUtilGAV)).thenReturn(daCoreVersionsBest);
-        when(versionFinderImpl.getBestMatchVersionFor(daUtilGAV)).thenReturn(bestMatchVersion);
+        when(versionFinderImpl.lookupBuiltVersions(daUtilGAV)).thenReturn(
+                new VersionLookupResult(Optional.ofNullable(bestMatchVersion), daCoreVersionsBest));
+        when(versionFinderImpl.getBestMatchVersionFor(daUtilGAV)).thenReturn(
+                Optional.ofNullable(bestMatchVersion));
+
         when(versionFinderImpl.getBestMatchVersionFor(daUtilGAV, daCoreVersionsBest)).thenReturn(
-                bestMatchVersion);
+                Optional.ofNullable(bestMatchVersion));
         when(blackArtifactService.isArtifactPresent(daUtilGAV)).thenReturn(false);
         when(whiteArtifactService.isArtifactPresent(daUtilGAV)).thenReturn(false);
 
         when(versionFinderImpl.getBuiltVersionsFor(daCommonGAV)).thenReturn(daCoreVersionsNoBest);
-        when(versionFinderImpl.getBestMatchVersionFor(daCommonGAV)).thenReturn(null);
+        when(versionFinderImpl.lookupBuiltVersions(daCommonGAV)).thenReturn(
+                new VersionLookupResult(Optional.empty(), daCoreVersionsNoBest));
+        when(versionFinderImpl.getBestMatchVersionFor(daCommonGAV)).thenReturn(Optional.empty());
+
         when(versionFinderImpl.getBestMatchVersionFor(daCommonGAV, daCoreVersionsNoBest))
-                .thenReturn(null);
+                .thenReturn(Optional.empty());
         when(blackArtifactService.isArtifactPresent(daCommonGAV)).thenReturn(false);
         when(whiteArtifactService.isArtifactPresent(daCommonGAV)).thenReturn(false);
     }
@@ -115,24 +126,23 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testNonExistingGAV() throws CommunicationException, NoGAVInRepositoryException {
-        when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenThrow(NoGAVInRepositoryException.class);
+    public void testNonExistingGAV() throws CommunicationException {
+        when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenReturn(Optional.empty());
 
-        ArtifactReport report = generator.getReport(daGAV);
+        Optional<ArtifactReport> report = generator.getReport(daGAV);
 
-        assertNull(report);
+        assertFalse(report.isPresent());
     }
 
     @Test
-    public void testNonListedNoBestMatchGAV() throws CommunicationException,
-            NoGAVInRepositoryException {
+    public void testNonListedNoBestMatchGAV() throws CommunicationException {
         prepare(false, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV);
+        ArtifactReport report = generator.getReport(daCoreGAV).get();
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
-        assertEquals(NO_BEST_MATCH_VERSION, report.getBestMatchVersion());
+        assertFalse(report.getBestMatchVersion().isPresent());
         assertTrue(report.getDependencies().isEmpty());
         assertFalse(report.isBlacklisted());
         assertFalse(report.isWhiteListed());
@@ -140,30 +150,28 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testWhiteListedNoBestMatchGAV() throws CommunicationException,
-            NoGAVInRepositoryException {
+    public void testWhiteListedNoBestMatchGAV() throws CommunicationException {
         prepare(true, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV);
+        ArtifactReport report = generator.getReport(daCoreGAV).get();
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
-        assertEquals(NO_BEST_MATCH_VERSION, report.getBestMatchVersion());
+        assertFalse(report.getBestMatchVersion().isPresent());
         assertTrue(report.getDependencies().isEmpty());
         assertFalse(report.isBlacklisted());
         assertTrue(report.isWhiteListed());
     }
 
     @Test
-    public void testBlackListedBestMatchGAV() throws CommunicationException,
-            NoGAVInRepositoryException {
+    public void testBlackListedBestMatchGAV() throws CommunicationException {
         prepare(false, true, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV);
+        ArtifactReport report = generator.getReport(daCoreGAV).get();
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
-        assertEquals(bestMatchVersion, report.getBestMatchVersion());
+        assertEquals(bestMatchVersion, report.getBestMatchVersion().get());
         assertTrue(report.getDependencies().isEmpty());
         assertTrue(report.isBlacklisted());
         assertFalse(report.isWhiteListed());
@@ -171,24 +179,24 @@ public class ReportsGeneratorImplTest {
 
     @Test
     public void testArtifactReportShouldNotHaveNullValuesInAvailableVersionsWhenBestMatchVersionIsNull()
-            throws CommunicationException, NoGAVInRepositoryException {
+            throws CommunicationException {
         prepare(false, false, daCoreVersionsBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV);
+        ArtifactReport report = generator.getReport(daCoreGAV).get();
 
-        assertNull(report.getBestMatchVersion());
+        assertFalse(report.getBestMatchVersion().isPresent());
         assertFalse(report.getAvailableVersions().stream().anyMatch(version -> version == null));
     }
 
     @Test
-    public void testGetMultipleReport() throws CommunicationException, NoGAVInRepositoryException {
+    public void testGetMultipleReport() throws CommunicationException {
         prepareMulti();
 
-        ArtifactReport report = generator.getReport(daCoreGAV);
+        ArtifactReport report = generator.getReport(daCoreGAV).get();
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
-        assertEquals(bestMatchVersion, report.getBestMatchVersion());
+        assertEquals(bestMatchVersion, report.getBestMatchVersion().get());
         assertFalse(report.isBlacklisted());
         assertFalse(report.isWhiteListed());
         assertMultipleDependencies(report.getDependencies());
@@ -204,7 +212,7 @@ public class ReportsGeneratorImplTest {
                     assertTrue(dep.getAvailableVersions().containsAll(daCoreVersionsBest));
                     assertEquals(daUtilGAV, dep.getGav());
                     assertNotNull(dep.getBestMatchVersion());
-                    assertEquals(bestMatchVersion, dep.getBestMatchVersion());
+                    assertEquals(bestMatchVersion, dep.getBestMatchVersion().get());
                     assertTrue(dep.getDependencies().isEmpty());
                     assertFalse(dep.isBlacklisted());
                     assertFalse(dep.isWhiteListed());
@@ -213,7 +221,7 @@ public class ReportsGeneratorImplTest {
                 case "common": {
                     assertTrue(dep.getAvailableVersions().containsAll(daCoreVersionsNoBest));
                     assertEquals(daCommonGAV, dep.getGav());
-                    assertNull(dep.getBestMatchVersion());
+                    assertFalse(dep.getBestMatchVersion().isPresent());
                     assertTrue(dep.getDependencies().isEmpty());
                     assertFalse(dep.isBlacklisted());
                     assertFalse(dep.isWhiteListed());


### PR DESCRIPTION
Optional is used at these places:
  Instead of NoGAVInRepositoryException
    AproxConnector returns Optional of GAVDependencyTree instead of
    throwing NoGAVInRepositoryException.

  Instead of null in Best match version
    Where best match version was used passed or stored, Optional is
    used - from VersionFinder, in VersionLookupResult and in
    ArtifactReport.
    In REST model (LookupReport and Report) null is still possible
    beacuse of mapping into JSON.

  Instead of null from ReportsGenerator
    ReportsGenerator returns Optional of ArtifactReport instead of null.

When no versions are found for a GA it means that there are no built
versions for that GA, so we don't have to handle it in special way.

  Where null was returned beacause of missing GA, empty list is now
  returned.

  This have the implication that response code 206 will never be used in
  /lookup/gavs