### PR TITLE
Rework B&W list so it is easier for user to use it - NO LIST version

### DIFF
--- a/cli/listings.sh
+++ b/cli/listings.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 target=ncl-test-vm-01.host.prod.eng.bos.redhat.com:8180/da/rest/v-0.2
+target=localhost:8080/da/rest/v-0.2
 
 basedir=`dirname $0`
 
@@ -95,7 +96,8 @@ check() {
     tmpfile=`mktemp`
     get "listings/${color}list/gav?groupid=${groupId}&artifactid=${artifactId}&version=${version}" > $tmpfile
     if grep -q '"contains":true' $tmpfile; then
-        echo "Artifact $groupId:$artifactId:$version is ${color}listed"
+        echo -n "Artifact $groupId:$artifactId:$version is ${color}listed - actual verisions in list: "
+        cat $tmpfile | prettyPrint ${color}listCheck
     elif grep -q '"contains":false' $tmpfile; then
         echo "Artifact $groupId:$artifactId:$version is NOT ${color}listed"
     else

--- a/cli/pretty.py
+++ b/cli/pretty.py
@@ -91,5 +91,19 @@ def lookup():
     for artifact in data:
         printLookup(artifact)
 
+def blacklistCheck():
+    data = readInput()
+    if data["found"]:
+        print data["found"]["version"]
+    else:
+        print ""
+
+def whitelistCheck():
+    data = readInput()
+    versions = []
+    for gav in data["found"]:
+        versions.append(gav["version"])
+    print ", ".join(versions)
+
 def hello():
     print "hi"

--- a/reports-backend/src/main/java/org/jboss/da/listings/api/dao/WhiteArtifactDAO.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/api/dao/WhiteArtifactDAO.java
@@ -1,5 +1,6 @@
 package org.jboss.da.listings.api.dao;
 
+import java.util.List;
 import org.jboss.da.listings.api.model.WhiteArtifact;
 
 /**
@@ -8,5 +9,7 @@ import org.jboss.da.listings.api.model.WhiteArtifact;
  *
  */
 public interface WhiteArtifactDAO extends ArtifactDAO<WhiteArtifact> {
+
+    public List<WhiteArtifact> findRedhatArtifact(String groupId, String artifactId, String version);
 
 }

--- a/reports-backend/src/main/java/org/jboss/da/listings/api/service/ArtifactService.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/api/service/ArtifactService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.listings.api.model.Artifact;
+import org.jboss.da.listings.api.model.WhiteArtifact;
 
 /**
  * 
@@ -23,22 +24,14 @@ public interface ArtifactService<T extends Artifact> {
      * @param groupId
      * @param artifactId
      * @param version
+     * @return Status of addition.
      */
     STATUS addArtifact(String groupId, String artifactId, String version);
 
     /**
-     * Finds artifact by given group id, artifact id and version. When not found returns null.
-     * 
-     * @param groupId
-     * @param artifactId
-     * @param version
-     * @return
-     */
-    T getArtifact(String groupId, String artifactId, String version);
-
-    /**
      * Checks if list contains artifact with specific groupId, artifactId and version.
-     * 
+     * All restrictions and conversions are applied like using getArtifact method of specific list.
+     *
      * @param groupId
      * @param artifactId
      * @param version
@@ -48,6 +41,7 @@ public interface ArtifactService<T extends Artifact> {
 
     /**
      * Checks if list contains artifact with specific GAV.
+     * All restrictions and conversions are applied like using getArtifact method of specific list.
      * @param gav
      * @return True if list contains the artifact otherwise false.
      */
@@ -61,12 +55,13 @@ public interface ArtifactService<T extends Artifact> {
     List<T> getAll();
 
     /**
-     * Remove artifact from list
+     * Remove artifact from list.
+     * Removes only exact match of artifact.
      * 
      * @param groupId
      * @param artifactId
      * @param version
-     * @return
+     * @return True if artifact was deleted.
      */
     boolean removeArtifact(String groupId, String artifactId, String version);
 

--- a/reports-backend/src/main/java/org/jboss/da/listings/api/service/BlackArtifactService.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/api/service/BlackArtifactService.java
@@ -1,5 +1,7 @@
 package org.jboss.da.listings.api.service;
 
+import java.util.Optional;
+import org.jboss.da.communication.model.GAV;
 import org.jboss.da.listings.api.model.BlackArtifact;
 
 /**
@@ -9,4 +11,29 @@ import org.jboss.da.listings.api.model.BlackArtifact;
  */
 public interface BlackArtifactService extends ArtifactService<BlackArtifact> {
 
+    /**
+     * Add artifact to blacklist.
+     * If the version contains redhat suffix it is removed. Then the version is converted to OSGi
+     * version. It also removes all redhat suffixed artifacts (with given groupId, artifactId and
+     * OSGi verison) from whitelist.
+     */
+    @Override
+    public STATUS addArtifact(String groupId, String artifactId, String version);
+
+    /**
+     * Checks if blacklist contains artifact with specific groupId, artifactId and version.
+     * If the version have redhat suffix it is removed. Then the version is converted to OSGi
+     * version and finds this version in blacklist;
+     * @return found artifact
+     */
+    public Optional<BlackArtifact> getArtifact(String groupId, String artifactId, String version);
+
+    /**
+     * Checks if blacklist contains artifact with specific groupId, artifactId and version.
+     * If the version have redhat suffix it is removed. Then the version is converted to OSGi
+     * version and finds this version in blacklist;
+     *
+     * @return found artifact
+     */
+    public Optional<BlackArtifact> getArtifact(GAV gav);
 }

--- a/reports-backend/src/main/java/org/jboss/da/listings/api/service/WhiteArtifactService.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/api/service/WhiteArtifactService.java
@@ -1,5 +1,7 @@
 package org.jboss.da.listings.api.service;
 
+import java.util.List;
+import org.jboss.da.communication.model.GAV;
 import org.jboss.da.listings.api.model.WhiteArtifact;
 
 /**
@@ -9,4 +11,30 @@ import org.jboss.da.listings.api.model.WhiteArtifact;
  */
 public interface WhiteArtifactService extends ArtifactService<WhiteArtifact> {
 
+    /**
+     * Add artifact to whitelist.
+     * The version must contain redhat suffix.
+     * @throws IllegalArgumentException when version doesn't have redhat suffix.
+     */
+    @Override
+    public STATUS addArtifact(String groupId, String artifactId, String version)
+            throws IllegalArgumentException;
+
+    /**
+     * Checks if whitelist contains artifact with specific groupId, artifactId and version.
+     * If the version have redhat suffix, find exact match. If the version doesn't have redhat 
+     * suffix, converts the version to OSGi version and finds any redhat suffixed versions
+     * in whitelist.
+     * @return List of found artifacts.
+     */
+    public List<WhiteArtifact> getArtifacts(GAV gav);
+
+    /**
+     * Checks if whitelist contains artifact with specific groupId, artifactId and version.
+     * If the version have redhat suffix, find exact match. If the version doesn't have redhat
+     * suffix, converts the version to OSGi version and finds any redhat suffixed versions
+     * in whitelist.
+     * @return List of found artifacts.
+     */
+    public List<WhiteArtifact> getArtifacts(String groupId, String artifactId, String version);
 }

--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/dao/WhiteArtifactDAOImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/dao/WhiteArtifactDAOImpl.java
@@ -1,6 +1,12 @@
 package org.jboss.da.listings.impl.dao;
 
+import java.util.List;
 import javax.ejb.Stateless;
+import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
 import org.jboss.da.listings.api.dao.WhiteArtifactDAO;
 import org.jboss.da.listings.api.model.WhiteArtifact;
@@ -16,5 +22,22 @@ public class WhiteArtifactDAOImpl extends ArtifactDAOImpl<WhiteArtifact> impleme
 
     public WhiteArtifactDAOImpl() {
         super(WhiteArtifact.class);
+    }
+
+    @Override
+    public List<WhiteArtifact> findRedhatArtifact(String groupId, String artifactId, String version) {
+        String dotVersion = version + ".redhat-%";
+        String dashVersion = version + "-redhat-%";
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<WhiteArtifact> cq = cb.createQuery(type);
+        Root<WhiteArtifact> artifact = cq.from(type);
+        cq.select(artifact).where(
+                cb.and(cb.equal(artifact.get("artifactId"), artifactId),
+                        cb.equal(artifact.get("groupId"), groupId),
+                        cb.or(cb.like(artifact.get("version"), dotVersion),
+                                cb.like(artifact.get("version"), dashVersion))));
+        TypedQuery<WhiteArtifact> q = em.createQuery(cq);
+        return q.getResultList();
     }
 }

--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/ArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/ArtifactServiceImpl.java
@@ -6,7 +6,10 @@ import org.jboss.da.listings.api.model.Artifact;
 import org.jboss.da.listings.api.service.ArtifactService;
 import org.slf4j.Logger;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
+import org.jboss.da.common.version.OSGiVersionParser;
+import org.jboss.da.reports.backend.impl.VersionFinderImpl;
 
 /**
  * 
@@ -21,6 +24,12 @@ public abstract class ArtifactServiceImpl<T extends Artifact> implements Artifac
 
     private final Class<T> type;
 
+    protected Pattern redhatSuffixPattern = Pattern
+            .compile(VersionFinderImpl.PATTERN_SUFFIX_BUILT_VERSION + "$");
+
+    @Inject
+    protected OSGiVersionParser osgiParser;
+
     public ArtifactServiceImpl(Class<T> type) {
         this.type = type;
     }
@@ -28,23 +37,13 @@ public abstract class ArtifactServiceImpl<T extends Artifact> implements Artifac
     protected abstract ArtifactDAO<T> getDAO();
 
     @Override
-    public T getArtifact(String groupId, String artifactId, String version) {
-        return getDAO().findArtifact(groupId, artifactId, version);
-    }
-
-    @Override
-    public boolean isArtifactPresent(String groupId, String artifactId, String version) {
-        return (getDAO().findArtifact(groupId, artifactId, version) != null);
+    public List<T> getAll() {
+        return getDAO().findAll();
     }
 
     @Override
     public boolean isArtifactPresent(GAV gav) {
-        return (getDAO().findArtifact(gav.getGroupId(), gav.getArtifactId(), gav.getVersion()) != null);
-    }
-
-    @Override
-    public List<T> getAll() {
-        return getDAO().findAll();
+        return isArtifactPresent(gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
     }
 
     @Override

--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/WhiteArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/WhiteArtifactServiceImpl.java
@@ -1,12 +1,16 @@
 package org.jboss.da.listings.impl.service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+import org.jboss.da.communication.model.GAV;
 
 import org.jboss.da.listings.api.dao.ArtifactDAO;
-import org.jboss.da.listings.api.dao.BlackArtifactDAO;
 import org.jboss.da.listings.api.dao.WhiteArtifactDAO;
 import org.jboss.da.listings.api.model.WhiteArtifact;
+import org.jboss.da.listings.api.service.BlackArtifactService;
 import org.jboss.da.listings.api.service.WhiteArtifactService;
 
 /**
@@ -23,7 +27,7 @@ public class WhiteArtifactServiceImpl extends ArtifactServiceImpl<WhiteArtifact>
     }
 
     @Inject
-    private BlackArtifactDAO blackArtifactDAO;
+    private BlackArtifactService blackArtifactService;
 
     @Inject
     private WhiteArtifactDAO whiteArtifactDAO;
@@ -36,8 +40,13 @@ public class WhiteArtifactServiceImpl extends ArtifactServiceImpl<WhiteArtifact>
     @Override
     public org.jboss.da.listings.api.service.ArtifactService.STATUS addArtifact(String groupId,
             String artifactId, String version) {
+        if (!redhatSuffixPattern.matcher(version).find()) {
+            throw new IllegalArgumentException("Version " + version
+                    + " doesn't contain redhat suffix");
+        }
+
         WhiteArtifact white = new WhiteArtifact(groupId, artifactId, version);
-        if (blackArtifactDAO.findArtifact(groupId, artifactId, version) != null) {
+        if (blackArtifactService.isArtifactPresent(groupId, artifactId, version)) {
             return STATUS.IS_BLACKLISTED;
         }
         if (whiteArtifactDAO.findArtifact(groupId, artifactId, version) != null) {
@@ -46,4 +55,26 @@ public class WhiteArtifactServiceImpl extends ArtifactServiceImpl<WhiteArtifact>
         whiteArtifactDAO.create(white);
         return STATUS.ADDED;
     }
+
+    @Override
+    public List<WhiteArtifact> getArtifacts(String groupId, String artifactId, String version) {
+        if(redhatSuffixPattern.matcher(version).find()){
+            return Optional.ofNullable(whiteArtifactDAO.findArtifact(groupId, artifactId, version))
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList());
+        }else{
+            return whiteArtifactDAO.findRedhatArtifact(groupId, artifactId, version);
+        }
+    }
+
+    @Override
+    public List<WhiteArtifact> getArtifacts(GAV gav) {
+        return getArtifacts(gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+    }
+
+    @Override
+    public boolean isArtifactPresent(String groupId, String artifactId, String version) {
+        return !getArtifacts(groupId, artifactId, version).isEmpty();
+    }
+
 }

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/VersionFinderImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/VersionFinderImpl.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class VersionFinderImpl implements VersionFinder {
 
-    private static final String PATTERN_SUFFIX_BUILT_VERSION = "[.-]redhat-(\\d+)\\D*";
+    public static final String PATTERN_SUFFIX_BUILT_VERSION = "[.-]redhat-([1-9]\\d*)";
 
     @Inject
     private AproxConnector aproxConnector;

--- a/reports-rest/src/main/java/org/jboss/da/rest/listings/RestConvert.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/listings/RestConvert.java
@@ -5,8 +5,8 @@ import org.jboss.da.rest.listings.model.RestArtifact;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 
@@ -17,15 +17,15 @@ import java.util.List;
 public class RestConvert {
 
     public <T extends Artifact> List<RestArtifact> toRestArtifacts(List<T> artifacts) {
-        List<RestArtifact> restArtifacts = new ArrayList<>();
-        for (Artifact a : artifacts) {
-            RestArtifact ra = new RestArtifact();
-            ra.setArtifactId(a.getArtifactId());
-            ra.setGroupId(a.getGroupId());
-            ra.setVersion(a.getVersion());
-            restArtifacts.add(ra);
-        }
-        return restArtifacts;
+        return artifacts.stream().map(RestConvert::toRestArtifact).collect(Collectors.toList());
+    }
+
+    public static RestArtifact toRestArtifact(Artifact a) {
+        RestArtifact ra = new RestArtifact();
+        ra.setArtifactId(a.getArtifactId());
+        ra.setGroupId(a.getGroupId());
+        ra.setVersion(a.getVersion());
+        return ra;
     }
 
 }

--- a/reports-rest/src/main/java/org/jboss/da/rest/listings/model/BlacklistContainsResponse.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/listings/model/BlacklistContainsResponse.java
@@ -1,5 +1,6 @@
 package org.jboss.da.rest.listings.model;
 
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -21,11 +22,15 @@ import lombok.ToString;
 @NoArgsConstructor
 @EqualsAndHashCode
 @ToString
-public class ContainsResponse {
+public class BlacklistContainsResponse {
 
     @Getter
     @Setter
     @XmlElement(required = true, name = "contains")
     protected boolean contains;
 
+    @Getter
+    @Setter
+    @XmlElement(required = false, name = "found")
+    private RestArtifact found;
 }

--- a/reports-rest/src/main/java/org/jboss/da/rest/listings/model/WhitelistContainsResponse.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/listings/model/WhitelistContainsResponse.java
@@ -1,0 +1,36 @@
+package org.jboss.da.rest.listings.model;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 
+ * @author Jozef Mrazek <jmrazek@redhat.com>
+ *
+ */
+@XmlRootElement(name = "contains")
+@XmlAccessorType(XmlAccessType.FIELD)
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class WhitelistContainsResponse {
+
+    @Getter
+    @Setter
+    @XmlElement(required = true, name = "contains")
+    protected boolean contains;
+
+    @Getter
+    @Setter
+    @XmlElement(required = true, name = "found")
+    private List<RestArtifact> found;
+}


### PR DESCRIPTION
In Whitelist we now allow only redhat versions of artifacts.
  If non-redhat version is being added, error 400 is returned.
  If redhat version is being checked, exact match is searched.
  If non-redhat version is being checked, it is converted to OSGi
  version and then all redhad version of this artifact are searched.

In Blacklist we now store non-redhat OSGi versions of artifact.
  If redhat version is being added, the redhat suffix is stripped and
  then converted to OSGi.
  If non-redhat version is being added, it is converted to OSGi version.
  If redhat version is being checked, the redhat suffix is stripped and
  then converted to OSGi.
  If non-redhat version is being checked, it is converted to OSGi version.


This version returns artifact or null when checking if artifact is in blacklist.
```json
{
    "contains":false,
    "found": null
}
```
```json
{
    "contains":false,
    "found": {
        "groupId":"org.jboss",
        "artifactId":"dependency-analysis",
        "version":"1.2.3.redhat-2"
     }
}
```