### PR TITLE
Fix White/Black list services bug caused by Stateless beans

### DIFF
--- a/common/src/main/java/org/jboss/da/common/version/OSGiVersionParser.java
+++ b/common/src/main/java/org/jboss/da/common/version/OSGiVersionParser.java
@@ -13,7 +13,7 @@ public class OSGiVersionParser {
      * @param version
      * @return
      */
-    
+
     public String getOSGiVersion(String version) {
         Version osgi;
         if (version.matches(".*[.-]redhat-(\\d+)")) {

--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/dao/GenericDAOImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/dao/GenericDAOImpl.java
@@ -53,7 +53,7 @@ public abstract class GenericDAOImpl<T extends GenericEntity> implements Generic
     public void delete(T entity) {
         requireNonNull(entity);
         requireNonNull(entity.getId());
-        em.remove(entity);
+        em.remove(em.getReference(type, entity.getId()));
     }
 
     @Override

--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/ArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/ArtifactServiceImpl.java
@@ -1,15 +1,16 @@
 package org.jboss.da.listings.impl.service;
 
+import org.jboss.da.common.version.OSGiVersionParser;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.listings.api.dao.ArtifactDAO;
 import org.jboss.da.listings.api.model.Artifact;
 import org.jboss.da.listings.api.service.ArtifactService;
-import org.slf4j.Logger;
+import org.jboss.da.reports.backend.impl.VersionFinderImpl;
+
+import javax.inject.Inject;
+
 import java.util.List;
 import java.util.regex.Pattern;
-import javax.inject.Inject;
-import org.jboss.da.common.version.OSGiVersionParser;
-import org.jboss.da.reports.backend.impl.VersionFinderImpl;
 
 /**
  * 
@@ -19,20 +20,11 @@ import org.jboss.da.reports.backend.impl.VersionFinderImpl;
  */
 public abstract class ArtifactServiceImpl<T extends Artifact> implements ArtifactService<T> {
 
-    @Inject
-    private Logger log;
-
-    private final Class<T> type;
-
     protected Pattern redhatSuffixPattern = Pattern
             .compile(VersionFinderImpl.PATTERN_SUFFIX_BUILT_VERSION + "$");
 
     @Inject
     protected OSGiVersionParser osgiParser;
-
-    public ArtifactServiceImpl(Class<T> type) {
-        this.type = type;
-    }
 
     protected abstract ArtifactDAO<T> getDAO();
 

--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/BlackArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/BlackArtifactServiceImpl.java
@@ -1,11 +1,6 @@
 package org.jboss.da.listings.impl.service;
 
-import java.util.List;
-import java.util.Optional;
-import javax.ejb.Stateless;
-import javax.inject.Inject;
 import org.jboss.da.communication.model.GAV;
-
 import org.jboss.da.listings.api.dao.ArtifactDAO;
 import org.jboss.da.listings.api.dao.BlackArtifactDAO;
 import org.jboss.da.listings.api.dao.WhiteArtifactDAO;
@@ -13,18 +8,20 @@ import org.jboss.da.listings.api.model.BlackArtifact;
 import org.jboss.da.listings.api.model.WhiteArtifact;
 import org.jboss.da.listings.api.service.BlackArtifactService;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 
  * @author Jozef Mrazek <jmrazek@redhat.com>
  *
  */
-@Stateless
+@ApplicationScoped
 public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact> implements
         BlackArtifactService {
-
-    public BlackArtifactServiceImpl() {
-        super(BlackArtifact.class);
-    }
 
     @Inject
     private BlackArtifactDAO blackArtifactDAO;

--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/WhiteArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/WhiteArtifactServiceImpl.java
@@ -1,30 +1,27 @@
 package org.jboss.da.listings.impl.service;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import javax.ejb.Stateless;
-import javax.inject.Inject;
 import org.jboss.da.communication.model.GAV;
-
 import org.jboss.da.listings.api.dao.ArtifactDAO;
 import org.jboss.da.listings.api.dao.WhiteArtifactDAO;
 import org.jboss.da.listings.api.model.WhiteArtifact;
 import org.jboss.da.listings.api.service.BlackArtifactService;
 import org.jboss.da.listings.api.service.WhiteArtifactService;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 
  * @author Jozef Mrazek <jmrazek@redhat.com>
  *
  */
-@Stateless
+@ApplicationScoped
 public class WhiteArtifactServiceImpl extends ArtifactServiceImpl<WhiteArtifact> implements
         WhiteArtifactService {
-
-    public WhiteArtifactServiceImpl() {
-        super(WhiteArtifact.class);
-    }
 
     @Inject
     private BlackArtifactService blackArtifactService;


### PR DESCRIPTION
If the exception in Stateless bean is thrown than it is wrapped with the EJB exception.
The CDI beans don't do this.