### PR TITLE
[DA-141] OSGi the redhat version before adding it to whitelist

### DIFF
--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/WhiteArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/WhiteArtifactServiceImpl.java
@@ -1,11 +1,13 @@
 package org.jboss.da.listings.impl.service;
 
+import org.jboss.da.common.version.OSGiVersionParser;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.listings.api.dao.ArtifactDAO;
 import org.jboss.da.listings.api.dao.WhiteArtifactDAO;
 import org.jboss.da.listings.api.model.WhiteArtifact;
 import org.jboss.da.listings.api.service.BlackArtifactService;
 import org.jboss.da.listings.api.service.WhiteArtifactService;
+import org.jboss.da.reports.backend.api.VersionFinder;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -29,6 +31,9 @@ public class WhiteArtifactServiceImpl extends ArtifactServiceImpl<WhiteArtifact>
     @Inject
     private WhiteArtifactDAO whiteArtifactDAO;
 
+    @Inject
+    private OSGiVersionParser osgiParser;
+
     @Override
     protected ArtifactDAO<WhiteArtifact> getDAO() {
         return whiteArtifactDAO;
@@ -41,6 +46,8 @@ public class WhiteArtifactServiceImpl extends ArtifactServiceImpl<WhiteArtifact>
             throw new IllegalArgumentException("Version " + version
                     + " doesn't contain redhat suffix");
         }
+
+        version = osgiParser.getOSGiVersion(version);
 
         WhiteArtifact white = new WhiteArtifact(groupId, artifactId, version);
         if (blackArtifactService.isArtifactPresent(groupId, artifactId, version)) {


### PR DESCRIPTION
This is to avoid errors with this case:

1. Add `haha:haha:1.0.redhat-1` to the whitelist
2. Add `haha:haha:1.0` to the blacklist
3. The artifact `haha:haha:1.0.redhat-1` is not moved to the blacklist