### PR TITLE
Add beans.xml to source-code-manager module

### DIFF
--- a/source-code-manager/src/main/resources/META-INF/beans.xml
+++ b/source-code-manager/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
+</beans>


### PR DESCRIPTION
This is apparently required to get Weld to inject the `SCM` object to other classes.