### PR TITLE
Fix AproxRemoteTest

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -55,18 +55,18 @@ public class AproxConnectorImpl implements AproxConnector {
         DepgraphAproxClientModule mod = new DepgraphAproxClientModule();
         try (Aprox aprox = new Aprox(config.getConfig().getAproxServer() + "/api", mod).connect()) {
 
+            SimpleProjectVersionRef rootRef = new SimpleProjectVersionRef(gav.getGroupId(),
+                    gav.getArtifactId(), gav.getVersion());
+
             ProjectGraphRequest req = mod
                     .newProjectGraphRequest()
-                    .withWorkspaceId("graph-export")
+                    .withWorkspaceId("export-" + rootRef.toString())
                     .withSource("group:public")
                     .withPatcherIds(DepgraphPatcherConstants.ALL_PATCHERS)
                     .withResolve(true)
                     .withGraph(
-                            mod.newGraphDescription()
-                                    .withRoots(
-                                            new SimpleProjectVersionRef(gav.getGroupId(), gav
-                                                    .getArtifactId(), gav.getVersion()))
-                                    .withPreset("requires").build()).build();
+                            mod.newGraphDescription().withRoots(rootRef).withPreset("requires")
+                                    .build()).build();
 
             GraphExport export = mod.graph(req);
 


### PR DESCRIPTION
Very recently Aprox started to give us more dependencies for a GAV than
it should, hence creating a failure in our AproxTest. It turns out that
some things have changed in Aprox, and this change is required to make
Aprox give back the correct list of dependencies for a GAV. The fix is
inspired from the `Gist.java` found here:

https://github.com/Commonjava/aprox-stack-examples/blob/master/aprox/aprox-depgraph-examples/src/main/java/org/commonjava/aprox/ex/Gist.java