### PR TITLE
[DA-132] Fix for cycle in dependency tree

### DIFF
--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -8,20 +8,21 @@ import org.jboss.da.listings.api.service.BlackArtifactService;
 import org.jboss.da.listings.api.service.WhiteArtifactService;
 import org.jboss.da.reports.api.ArtifactReport;
 import org.jboss.da.reports.api.VersionLookupResult;
+import org.jboss.da.reports.backend.api.DependencyTreeGenerator;
 import org.jboss.da.reports.backend.api.VersionFinder;
+import org.jboss.da.reports.backend.impl.DependencyTreeGeneratorImpl;
 import org.junit.runner.RunWith;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Spy;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.jboss.da.reports.backend.api.DependencyTreeGenerator;
-import org.jboss.da.reports.backend.impl.DependencyTreeGeneratorImpl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -29,7 +30,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
-import org.mockito.Spy;
 
 /**
  *


### PR DESCRIPTION
The fix is actually not really a fix.

The `GAVDependencyTree` generated is a huge tree where checking if a
cycle happened through its dependencies can be problematic and time
consuming.

Instead, the fix involves keeping a set of `GAVDependencyTree` nodes
already visited once it has been processed in `ReportsGenerator`. This
then allows us to:

- display the GAV and its dependencies the first time it is encountered
- only display the GAV the other subsequent times it is encountered.

This has the effect of:

1. Not getting the `ReportsGenerator` stuck in an infinite loop because
   of cycles in `GAVDependencyTree`

2. Produce skinner reports since we now don't show the dependencies for
   a GAV everytime it in encountered while generating the report, we
   only show it once.