### PR TITLE
[DA-145][DA-148] Fix for projects analysis with cli

### DIFF
--- a/cli/listings.sh
+++ b/cli/listings.sh
@@ -218,12 +218,19 @@ pom_bw() {
     tmpfile=`gettmpfile`
     pushd "${pom_path}" > /dev/null
     mvn -q dependency:list -DoutputFile=$tmpfile -DappendOutput=true $mvn_opts
-    popd > /dev/null
 
     if [ $? -ne 0 ]; then
         rm $tmpfile
+        echo ""
+        echo ""
+        echo "================================================================="
+        echo "'mvn dependency:list' command failed."
+        echo "Consider running 'mvn clean install' before running the pom-bw command again to fix the issue"
+        echo "================================================================="
         exit
     fi
+
+    popd > /dev/null
 
     sort -u $tmpfile | grep "^ *.*:.*:.*:.*"| sed "s/^ *//" | awk 'BEGIN {IFS=":"; FS=":"; OFS=":"} {print $1,$2,$4}' | while read line; do
         wresp=`check white $line`
@@ -273,12 +280,19 @@ pom_report() {
 
     pushd "${pom_path}" > /dev/null
     mvn -q dependency:list -DoutputFile=$tmpfile -DappendOutput=true $mvn_opts
-    popd > /dev/null
 
     if [ $? -ne 0 ]; then
         rm $tmpfile
+        echo ""
+        echo ""
+        echo "================================================================="
+        echo "'mvn dependency:list' command failed."
+        echo "Consider running 'mvn clean install' before running the pom-report command again to fix the issue"
+        echo "================================================================="
         exit
     fi
+
+    popd > /dev/null
 
     sort -u $tmpfile | grep "^ *.*:.*:.*:.*"| sed "s/^ *//" | awk 'BEGIN {IFS=":"; FS=":"; OFS=":"} {print $1,$2,$4}' | while read line; do
         report_result=`report $raw_output $line`


### PR DESCRIPTION
Some projects' dependencies cannot be analyzed using the 'da-cli.sh'
script (for pom-bw and pom-report) because the `mvn dependency:list`
command fails.

This typically happens when we are missing an artifact which only gets
produced during the package phase.

The fix is to capture the failure and recommend the user to run `mvn
clean install` before running the 'da-cli.sh' script again.