### PR TITLE
[DA-72]: Solve reauthentication to Keycloak, when token expires

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
@@ -1,12 +1,12 @@
 package org.jboss.da.communication.pnc.api;
 
-import java.util.List;
-
 import org.jboss.da.communication.pnc.model.BuildConfiguration;
 import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
 import org.jboss.da.communication.pnc.model.BuildConfigurationSet;
 import org.jboss.da.communication.pnc.model.Product;
 import org.jboss.da.communication.pnc.model.Project;
+
+import java.util.List;
 
 /**
  *
@@ -30,6 +30,24 @@ public interface PNCConnector {
             throws Exception;
 
     BuildConfiguration createBuildConfiguration(BuildConfigurationCreate bc) throws Exception;
+
+    /**
+     * Deletes BuildConfiguration from PNC by ID of the BC
+     * 
+     * @param bc BC to be deleted
+     * @return True, if the BC was successfully removed, otherwise false
+     * @throws Exception Thrown if the communication with PNC failed
+     */
+    boolean deleteBuildConfiguration(BuildConfiguration bc) throws Exception;
+
+    /**
+     * Deletes BuildConfiguration from PNC by ID of the BC
+     * 
+     * @param bcId ID of BC to be deleted
+     * @return True, if the BC was successfully removed, otherwise false
+     * @throws Exception Thrown if the communication with PNC failed
+     */
+    boolean deleteBuildConfiguration(int bcId) throws Exception;
 
     BuildConfigurationSet createBuildConfigurationSet(BuildConfigurationSet bcs) throws Exception;
 

--- a/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PNCAuthentication.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PNCAuthentication.java
@@ -1,14 +1,5 @@
 package org.jboss.da.communication.pnc.authentication;
 
-import java.io.BufferedReader;
-
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -20,31 +11,70 @@ import org.jboss.da.common.json.DAConfig;
 import org.jboss.da.common.util.Configuration;
 import org.jboss.da.common.util.ConfigurationParseException;
 
+import javax.annotation.PostConstruct;
+import javax.ejb.Lock;
+import javax.ejb.LockType;
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Getter;
+
 /**
  * Class obtained from pnc example on OAuth example on PNCProducer:
- * https://github.com/project-ncl/pnc/blob/master/examples/oauth-client/src/main/java/org/jboss/pnc/auth/client/SimpleOAuthConnect.java
+ * https://github.com/project-ncl/pnc/blob/master/examples/oauth-client/src/main/java/org/jboss/pnc/auth/client/
+ * SimpleOAuthConnect.java
  */
+@SuppressWarnings("unused")
+@Singleton
 public class PNCAuthentication {
 
-    Configuration config = new Configuration();
+    @Inject
+    private Configuration config;
 
-    public static String getAccessToken(String url, Map<String, String> urlParams)
+    @Getter
+    private String accessToken;
+
+    public void authenticate() {
+        try {
+            DAConfig conf = config.getConfig();
+            String keycloakServer = conf.getKeycloakServer();
+            String realm = conf.getKeycloakRealm();
+            String clientId = conf.getKeycloakClientid();
+            String username = conf.getKeycloakUsername();
+            String password = conf.getKeycloakPassword();
+
+            accessToken = getAccessToken(keycloakServer + "/auth/realms/" + realm
+                    + "/tokens/grants/access", clientId, username, password);
+        } catch (IOException | ConfigurationParseException e) {
+            throw new RuntimeException("Failed to authenticate", e);
+        }
+    }
+
+    private String getAccessToken(String url, Map<String, String> urlParams)
             throws ClientProtocolException, IOException {
         return connect(url, urlParams)[0];
     }
 
-    public static String getRefreshToken(String url, Map<String, String> urlParams)
+    private String getRefreshToken(String url, Map<String, String> urlParams)
             throws ClientProtocolException, IOException {
         return connect(url, urlParams)[1];
     }
 
-    public static String[] getTokens(String url, Map<String, String> urlParams)
+    private String[] getTokens(String url, Map<String, String> urlParams)
             throws ClientProtocolException, IOException {
         return connect(url, urlParams);
     }
 
-    public static String getAccessToken(String url, String clientId, String username,
-            String password) throws ClientProtocolException, IOException {
+    private String getAccessToken(String url, String clientId, String username, String password)
+            throws ClientProtocolException, IOException {
         Map<String, String> urlParams = new HashMap<>();
         urlParams.put("grant_type", "password");
         urlParams.put("client_id", clientId);
@@ -53,8 +83,8 @@ public class PNCAuthentication {
         return connect(url, urlParams)[0];
     }
 
-    public static String getrefreshToken(String url, String clientId, String username,
-            String password) throws ClientProtocolException, IOException {
+    private String getrefreshToken(String url, String clientId, String username, String password)
+            throws ClientProtocolException, IOException {
         Map<String, String> urlParams = new HashMap<>();
         urlParams.put("grant_type", "password");
         urlParams.put("client_id", clientId);
@@ -63,7 +93,7 @@ public class PNCAuthentication {
         return connect(url, urlParams)[1];
     }
 
-    private static String[] connect(String url, Map<String, String> urlParams)
+    private String[] connect(String url, Map<String, String> urlParams)
             throws ClientProtocolException, IOException {
 
         CloseableHttpClient httpclient = HttpClients.createDefault();
@@ -105,21 +135,5 @@ public class PNCAuthentication {
         }
         return new String[] { accessToken, refreshToken };
 
-    }
-
-    public String authenticate() {
-        try {
-            DAConfig conf = config.getConfig();
-            String keycloakServer = conf.getKeycloakServer();
-            String realm = conf.getKeycloakRealm();
-            String clientId = conf.getKeycloakClientid();
-            String username = conf.getKeycloakUsername();
-            String password = conf.getKeycloakPassword();
-
-            return PNCAuthentication.getAccessToken(keycloakServer + "/auth/realms/" + realm
-                    + "/tokens/grants/access", clientId, username, password);
-        } catch (IOException | ConfigurationParseException e) {
-            throw new RuntimeException("Failed to authenticate", e);
-        }
     }
 }

--- a/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PncAuthenticated.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PncAuthenticated.java
@@ -1,0 +1,15 @@
+package org.jboss.da.communication.pnc.authentication;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import javax.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Target({ METHOD, TYPE })
+@Retention(RUNTIME)
+public @interface PncAuthenticated {
+}

--- a/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PncAuthenticationInterceptor.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PncAuthenticationInterceptor.java
@@ -1,0 +1,34 @@
+package org.jboss.da.communication.pnc.authentication;
+
+import org.jboss.da.communication.pnc.impl.AuthenticationException;
+
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+/**
+ * Interceptor, which takes care of authenticating to PNC, when the access token is invalid.
+ * 
+ * @author Jakub Bartecek <jbartece@redhat.com>
+ *
+ */
+@Interceptor
+@PncAuthenticated
+public class PncAuthenticationInterceptor {
+
+    @Inject
+    private PNCAuthentication pncAuthentication;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        try {
+            return ctx.proceed();
+        } catch (AuthenticationException e) {
+            // TODO solve multiple authentication because of concurrency
+            pncAuthentication.authenticate();
+            return ctx.proceed();
+        }
+    }
+
+}

--- a/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PncAuthenticationInterceptor.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/authentication/PncAuthenticationInterceptor.java
@@ -25,8 +25,7 @@ public class PncAuthenticationInterceptor {
         try {
             return ctx.proceed();
         } catch (AuthenticationException e) {
-            // TODO solve multiple authentication because of concurrency
-            pncAuthentication.authenticate();
+            pncAuthentication.authenticate(e.getAccessToken());
             return ctx.proceed();
         }
     }

--- a/communication/src/main/java/org/jboss/da/communication/pnc/impl/AuthenticationException.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/impl/AuthenticationException.java
@@ -1,0 +1,16 @@
+package org.jboss.da.communication.pnc.impl;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class AuthenticationException extends Exception {
+
+    public AuthenticationException(String msg) {
+        super(msg);
+    }
+
+    public AuthenticationException(String msg, Throwable ex) {
+        super(msg, ex);
+    }
+
+}

--- a/communication/src/main/java/org/jboss/da/communication/pnc/impl/AuthenticationException.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/impl/AuthenticationException.java
@@ -1,16 +1,36 @@
 package org.jboss.da.communication.pnc.impl;
 
-import lombok.NoArgsConstructor;
+import javax.validation.constraints.NotNull;
 
-@NoArgsConstructor
+import lombok.Getter;
+
+/**
+ * Exception, which is used to report issues with authentication
+ * 
+ * @author Jakub Bartecek <jbartece@redhat.com>
+ *
+ */
 public class AuthenticationException extends Exception {
 
-    public AuthenticationException(String msg) {
-        super(msg);
+    /**
+     * Access token with which authentication failed
+     */
+    @NotNull
+    @Getter
+    private final String accessToken;
+
+    public AuthenticationException(String accessToken) {
+        this.accessToken = accessToken;
     }
 
-    public AuthenticationException(String msg, Throwable ex) {
+    public AuthenticationException(String msg, String accessToken) {
+        super(msg);
+        this.accessToken = accessToken;
+    }
+
+    public AuthenticationException(String msg, Throwable ex, String accessToken) {
         super(msg, ex);
+        this.accessToken = accessToken;
     }
 
 }

--- a/communication/src/main/java/org/jboss/da/communication/pnc/model/Project.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/model/Project.java
@@ -1,9 +1,12 @@
 package org.jboss.da.communication.pnc.model;
 
 import java.util.List;
+
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
+@ToString
 public class Project {
 
     @Getter

--- a/communication/src/main/resources/META-INF/beans.xml
+++ b/communication/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,10 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
         http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="annotated">
+        bean-discovery-mode="annotated">
+    <interceptors>
+        <class>org.jboss.da.communication.pnc.authentication.PncAuthenticationInterceptor</class>
+    </interceptors>
 </beans>

--- a/communication/src/test/java/org/jboss/da/communication/PNCConnectorImplTest.java
+++ b/communication/src/test/java/org/jboss/da/communication/PNCConnectorImplTest.java
@@ -26,7 +26,7 @@ public class PNCConnectorImplTest {
 
     private final String token = "magic_token";
 
-    private final String PNC_BASE_URL = "http://10.19.208.25:8180";
+    private final String PNC_BASE_URL = "http://10.10.10.10:8080";
 
     @Spy
     private Configuration configuration = new Configuration();
@@ -47,22 +47,15 @@ public class PNCConnectorImplTest {
     }
 
     @Test
-    public void shouldGenerateRightUriBasedOnPncServerAndEndpoint() throws Exception {
-        ClientRequest req = pncConnectorImpl.getClient("matin");
-        assertEquals(PNC_BASE_URL + "/pnc-rest/rest/matin", req.getUri());
-    }
-
-    @Test
     public void shouldGenerateRightUriBasedOnPncServerAndEndpointAuthenticated() throws Exception {
-        ClientRequest req = pncConnectorImpl.getAuthenticatedClient("gabriella");
+        ClientRequest req = pncConnectorImpl.getClient("gabriella");
         assertEquals(PNC_BASE_URL + "/pnc-rest/rest/gabriella", req.getUri());
     }
 
     @Test
     public void shouldAddAuthenticationTokenToHeaderForAuthenticatedEndpoint() throws Exception {
-        when(pncAuthenticate.authenticate()).thenReturn(token);
-
-        ClientRequest req = pncConnectorImpl.getAuthenticatedClient("testme");
+        when(pncAuthenticate.getAccessToken()).thenReturn(token);
+        ClientRequest req = pncConnectorImpl.getClient("testme");
 
         MultivaluedMap<String, String> headers = req.getHeaders();
         assertTrue(headers.containsKey("Authorization"));

--- a/communication/src/test/java/org/jboss/da/communication/PNCConnectorImplTest.java
+++ b/communication/src/test/java/org/jboss/da/communication/PNCConnectorImplTest.java
@@ -47,15 +47,14 @@ public class PNCConnectorImplTest {
     }
 
     @Test
-    public void shouldGenerateRightUriBasedOnPncServerAndEndpointAuthenticated() throws Exception {
-        ClientRequest req = pncConnectorImpl.getClient("gabriella");
+    public void shouldGenerateRightUriForRequest() throws Exception {
+        ClientRequest req = pncConnectorImpl.getClient("gabriella", "");
         assertEquals(PNC_BASE_URL + "/pnc-rest/rest/gabriella", req.getUri());
     }
 
     @Test
-    public void shouldAddAuthenticationTokenToHeaderForAuthenticatedEndpoint() throws Exception {
-        when(pncAuthenticate.getAccessToken()).thenReturn(token);
-        ClientRequest req = pncConnectorImpl.getClient("testme");
+    public void shouldAddAuthenticationTokenToHeader() throws Exception {
+        ClientRequest req = pncConnectorImpl.getClient("testme", token);
 
         MultivaluedMap<String, String> headers = req.getHeaders();
         assertTrue(headers.containsKey("Authorization"));

--- a/testsuite/src/test/resources/META-INF/beans.xml
+++ b/testsuite/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
+        http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+        bean-discovery-mode="annotated">
+    <interceptors>
+        <class>org.jboss.da.communication.pnc.authentication.PncAuthenticationInterceptor</class>
+    </interceptors>
+</beans>


### PR DESCRIPTION
New interceptor is created, which solves the situation, when access token expired. When it happens,
it triggers reauthentication and force reexecution of the called method in PNC connector

PNCAuthentication class was reworked to be a bean

Integration test for PNCConnector was created

Beans.xml file in communication was fixed to support interceptors