### PR TITLE
Refactor BuildConfigurationGeneratorImpl into ProjectHiearchyCreator

### DIFF
--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/api/POMInfoGenerator.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/api/POMInfoGenerator.java
@@ -13,9 +13,12 @@ import org.jboss.da.communication.pom.PomAnalysisException;
 public interface POMInfoGenerator {
 
     public Optional<POMInfo> getPomInfo(String url, String revision, String pomPath)
-            throws ScmException, PomAnalysisException;
+            throws ScmException;
 
     public Optional<POMInfo> getPomInfo(GAV gav) throws CommunicationException,
             PomAnalysisException;
+
+    public Optional<POMInfo> getPomInfo(String scmUrl, String scmRevision, GAV gav)
+            throws ScmException;
 
 }

--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/POMInfoGeneratorImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/POMInfoGeneratorImpl.java
@@ -25,7 +25,7 @@ public class POMInfoGeneratorImpl implements POMInfoGenerator {
     AproxConnector aprox;
 
     @Override
-    public Optional<POMInfo> getPomInfo(String url, String revision, String pomPath) throws ScmException, PomAnalysisException {
+    public Optional<POMInfo> getPomInfo(String url, String revision, String pomPath) throws ScmException {
         Optional<MavenProject> pom = scm.getPom(url, revision, pomPath);
         return pom.map(x -> toPomInfo(x));
     }
@@ -43,4 +43,9 @@ public class POMInfoGeneratorImpl implements POMInfoGenerator {
         return new POMInfo(gav, url, tag, pom.getName());
     }
 
+    @Override
+    public Optional<POMInfo> getPomInfo(String scmUrl, String scmRevision, GAV gav) throws ScmException {
+        Optional<MavenProject> pom = scm.getPom(scmUrl, scmRevision, gav);
+        return pom.map(x -> toPomInfo(x));
+    }
 }

--- a/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
@@ -1,37 +1,22 @@
 package org.jboss.da.bc.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import org.jboss.da.bc.backend.api.POMInfo;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.bc.api.BuildConfigurationGenerator;
-import org.jboss.da.bc.backend.api.BCSetGenerator;
-import org.jboss.da.bc.backend.api.BcChecker;
 import org.jboss.da.bc.backend.api.Finalizer;
 import org.jboss.da.bc.backend.api.POMInfoGenerator;
-import org.jboss.da.bc.backend.api.RepositoryCloner;
 import org.jboss.da.bc.model.GeneratorEntity;
 import org.jboss.da.bc.model.ProjectDetail;
 import org.jboss.da.bc.model.ProjectHiearchy;
-import org.jboss.da.communication.CommunicationException;
-import org.jboss.da.communication.model.GAV;
-import org.jboss.da.communication.pnc.api.PNCConnector;
-import org.jboss.da.communication.pnc.model.BuildConfiguration;
-import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
 import org.jboss.da.communication.pom.PomAnalysisException;
 import org.jboss.da.reports.api.SCMLocator;
 import org.jboss.da.reports.backend.api.DependencyTreeGenerator;
 import org.jboss.da.reports.backend.api.GAVToplevelDependencies;
-import org.jboss.da.reports.backend.api.VersionFinder;
-import org.jboss.da.scm.api.SCMType;
 import org.slf4j.Logger;
 
 /**
@@ -51,18 +36,14 @@ public class BuildConfigurationGeneratorImpl implements BuildConfigurationGenera
     private POMInfoGenerator pom;
 
     @Inject
-    private VersionFinder versionFinder;
-
-    @Inject
     private Finalizer finalizer;
 
     @Inject
-    private BcChecker bcFinder;
+    private ProjectHiearchyCreator nextLevel;
 
     @Override
     public GeneratorEntity startBCGeneration(SCMLocator scm, String productName,
-            String productVersion) throws CommunicationException, ScmException,
-            PomAnalysisException {
+            String productVersion) throws ScmException, PomAnalysisException {
         GAVToplevelDependencies deps = depGenerator.getToplevelDependencies(scm);
         Optional<POMInfo> pomInfo = pom.getPomInfo(scm.getScmUrl(), scm.getRevision(),
                 scm.getPomPath());
@@ -70,20 +51,19 @@ public class BuildConfigurationGeneratorImpl implements BuildConfigurationGenera
         GeneratorEntity ge = new GeneratorEntity(scm, productName, deps.getGav(), productVersion);
         ge.setBcSetName(deps.getGav().toString());
 
-        setProjectInfoFromPom(ge.getToplevelProject(), pomInfo);
-        ge.getToplevelProject().setName(getName(deps.getGav()));
+        ge.getToplevelProject().setDescription(
+                ProjectHiearchyCreator.getDescription(pomInfo, deps.getGav()));
+        ge.getToplevelProject().setName(ProjectHiearchyCreator.getName(deps.getGav()));
 
         ge.getToplevelBc().setDependencies(
-                Optional.of(toProjectHierarchies(deps.getDependencies())));
+                Optional.of(nextLevel.processDependencies(ge, deps.getDependencies())));
 
         return ge;
     }
 
     @Override
-    public GeneratorEntity iterateBCGeneration(GeneratorEntity projects)
-            throws CommunicationException {
-        iterateDependencies(projects.getToplevelBc(), projects);
-        return projects;
+    public GeneratorEntity iterateBCGeneration(GeneratorEntity projects) {
+        return nextLevel.iterateNextLevel(projects);
     }
 
     @Override
@@ -99,112 +79,6 @@ public class BuildConfigurationGeneratorImpl implements BuildConfigurationGenera
 
         return finalizer.createBCs(projects.getName(), projects.getProductVersion(),
                 projects.getToplevelBc(), projects.getBcSetName());
-    }
-
-    private ProjectHiearchy iterateDependencies(ProjectHiearchy hiearchy, GeneratorEntity entity)
-            throws CommunicationException {
-        Optional<Set<ProjectHiearchy>> deps = hiearchy.getDependencies();
-        if (hiearchy.isSelected() && deps.isPresent()) {
-            if (deps.get().isEmpty()) {
-                GAV gav = hiearchy.getProject().getGav();
-                hiearchy.setDependencies(getDependencies(gav, entity));
-            } else {
-                for (ProjectHiearchy dep : deps.get()) {
-                    iterateDependencies(dep, entity);
-                }
-            }
-        }
-        return hiearchy;
-    }
-
-    /**
-     * Tries to find dependencies in AProx, if not found in AProx, try to found in the original SCM
-     * repository.
-     */
-    private Optional<Set<ProjectHiearchy>> getDependencies(GAV gav, GeneratorEntity entity) throws CommunicationException {
-        Optional<GAVToplevelDependencies> gavs = depGenerator.getToplevelDependencies(gav);
-        if(!gavs.isPresent()){
-            ProjectDetail project = entity.getToplevelProject();
-            try {
-                gavs = Optional.of(depGenerator.getToplevelDependencies(project.getScmUrl(), project.getScmRevision(), gav));
-            } catch (ScmException | PomAnalysisException ex) {
-                return Optional.empty();
-            }
-        }
-
-        return gavs.map(x -> toProjectHierarchies(x.getDependencies()));
-    }
-
-    private Set toProjectHierarchies(Collection<GAV> gavs){
-        return gavs.stream().map(gav -> toProjectHiearchy(gav)).collect(Collectors.toSet());
-    }
-
-    /**
-     * Creates new ProjectHiearchy from GAV.
-     * Tries to get pom file for GAV and if
-     */
-    private ProjectHiearchy toProjectHiearchy(GAV gav) {
-        ProjectDetail project = new ProjectDetail(gav);
-        project.setName(getName(gav));
-        tryGetInfoFromPom(project, gav);
-
-        try {
-            project.setInternallyBuilt(versionFinder.getBestMatchVersionFor(gav));
-        } catch (CommunicationException ex) {
-            log.error("Could not obtain best match version", ex);
-        }
-
-        ProjectHiearchy ph = new ProjectHiearchy(project, false);
-        return ph;
-    }
-
-    /**
-     * Tries to get pomfile for given GAV and fill Project detail with informations from pomfile.
-     * Also tries to find if build configuration for this GAV already exists.
-     */
-    private void tryGetInfoFromPom(ProjectDetail project, GAV gav) {
-        try {
-            Optional<POMInfo> pomInfo = pom.getPomInfo(gav);
-
-            setProjectInfoFromPom(project, pomInfo);
-            setSCMData(project, pomInfo);
-
-            Optional<BuildConfiguration> bc = findExistingBuildConfiguration(pomInfo);
-            project.setBcExists(bc.isPresent());
-            project.setUseExistingBc(bc.isPresent());
-        } catch (Exception ex) {
-            log.error("Could not obtain pom info.", ex);
-        }
-    }
-
-    private String getDescription(POMInfo pomInfo) {
-        Optional<String> name = pomInfo.getName();
-
-        return name.map(n -> String.format("Build Configuration for %s - %s.", pomInfo.getGav(), n))
-                   .orElse(String.format("Build Configuration for %s.", pomInfo.getGav()));
-    }
-
-    private String getName(GAV gav) {
-        return String.format("%s-%s", gav.getArtifactId(), gav.getVersion());
-    }
-
-    private void setSCMData(ProjectDetail project, Optional<POMInfo> pomInfo) {
-        pomInfo.flatMap(POMInfo::getScmURL).ifPresent(url -> project.setScmUrl(url));
-        pomInfo.flatMap(POMInfo::getScmURL).ifPresent(revison -> project.setScmUrl(revison));
-    }
-
-    private void setProjectInfoFromPom(ProjectDetail project, Optional<POMInfo> pomInfo) {
-        pomInfo.ifPresent(info -> project.setDescription(getDescription(info)));
-    }
-
-    private Optional<BuildConfiguration> findExistingBuildConfiguration(Optional<POMInfo> pomInfo) throws Exception {
-        Optional<String> url = pomInfo.flatMap(POMInfo::getScmURL);
-        Optional<String> revision = pomInfo.flatMap(POMInfo::getScmRevision);
-        if(url.isPresent() && revision.isPresent()){
-            return bcFinder.lookupBcByScm(url.get(), revision.get());
-        }else{
-            return Optional.empty();
-        }
     }
 
     private void validate(ProjectHiearchy hiearchy) throws IllegalStateException {

--- a/bc-backend/src/main/java/org/jboss/da/bc/impl/ProjectHiearchyCreator.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/impl/ProjectHiearchyCreator.java
@@ -1,0 +1,245 @@
+package org.jboss.da.bc.impl;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import org.apache.maven.scm.ScmException;
+import org.jboss.da.bc.backend.api.BcChecker;
+import org.jboss.da.bc.backend.api.POMInfo;
+import org.jboss.da.bc.backend.api.POMInfoGenerator;
+import org.jboss.da.bc.model.GeneratorEntity;
+import org.jboss.da.bc.model.ProjectDetail;
+import org.jboss.da.bc.model.ProjectHiearchy;
+import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.model.GAV;
+import org.jboss.da.communication.pnc.model.BuildConfiguration;
+import org.jboss.da.communication.pom.PomAnalysisException;
+import org.jboss.da.communication.scm.api.SCMConnector;
+import org.jboss.da.reports.backend.api.DependencyTreeGenerator;
+import org.jboss.da.reports.backend.api.GAVToplevelDependencies;
+import org.jboss.da.reports.backend.api.VersionFinder;
+import org.slf4j.Logger;
+
+/**
+ *
+ * @author Honza Brázdil <jbrazdil@redhat.com>
+ */
+@Stateless
+public class ProjectHiearchyCreator {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private DependencyTreeGenerator depGenerator;
+
+    @Inject
+    private POMInfoGenerator pom;
+
+    @Inject
+    private SCMConnector scm;
+
+    @Inject
+    private BcChecker bcFinder;
+
+    @Inject
+    private VersionFinder versionFinder;
+
+    private GeneratorEntity entity;
+
+    private String scmUrl;
+
+    private String revison;
+
+    public GeneratorEntity iterateNextLevel(GeneratorEntity entity) {
+        this.entity = entity;
+        this.scmUrl = entity.getToplevelProject().getScmUrl();
+        this.revison = entity.getToplevelProject().getScmRevision();
+
+        iterate(entity.getToplevelBc());
+        return entity;
+    }
+
+    public Set<ProjectHiearchy> processDependencies(GeneratorEntity entity,
+            Collection<GAV> dependencies) {
+        this.entity = entity;
+        this.scmUrl = entity.getToplevelProject().getScmUrl();
+        this.revison = entity.getToplevelProject().getScmRevision();
+
+        return toProjectHiearchies(dependencies);
+    }
+
+    /**
+     * Iterate and fill next level dependencies where selected
+     */
+    private void iterate(ProjectHiearchy hiearchy) {
+        if (!hiearchy.isSelected())
+            return; // Not selected, ignoring
+
+        Optional<Set<ProjectHiearchy>> dependencies = hiearchy.getDependencies();
+        if (!dependencies.isPresent())
+            return; // Dependencies were already check with error, ignoring
+
+        if (dependencies.get().isEmpty()) { // Dependencies not yet processed, get and process them
+            GAV gav = hiearchy.getProject().getGav();
+            Optional<GAVToplevelDependencies> deps = getDependencies(gav);
+            hiearchy.setDependencies(toProjectHiearchies(deps));
+        } else { // Dependencies already processed, search next level
+            for (ProjectHiearchy dep : dependencies.get()) {
+                iterate(dep);
+            }
+        }
+    }
+
+    /**
+     * Tries to find dependencies in AProx, if not found in AProx, try to found in the original SCM
+     * repository.
+     */
+    private Optional<GAVToplevelDependencies> getDependencies(GAV gav) {
+        try {
+            Optional<GAVToplevelDependencies> dependencies = depGenerator
+                    .getToplevelDependencies(gav);
+            if (!dependencies.isPresent()) {
+                ProjectDetail project = entity.getToplevelProject();
+                try {
+                    dependencies = Optional.of(depGenerator.getToplevelDependencies(
+                            project.getScmUrl(), project.getScmRevision(), gav));
+                } catch (ScmException | PomAnalysisException ex) {
+                    return Optional.empty();
+                }
+            }
+            return dependencies;
+        } catch (CommunicationException ex) {
+            log.warn("Failed to get dependencies for " + gav, ex);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<Set<ProjectHiearchy>> toProjectHiearchies(Optional<GAVToplevelDependencies> deps) {
+        return deps.map(x -> toProjectHiearchies(x.getDependencies()));
+    }
+
+    private Set<ProjectHiearchy> toProjectHiearchies(Collection<GAV> gavs) {
+        return gavs.stream().map(dep -> toProjectHiearchy(dep)).collect(Collectors.toSet());
+    }
+
+    /**
+     * Creates new ProjectHiearchy from GAV.
+     */
+    private ProjectHiearchy toProjectHiearchy(GAV gav) {
+        ProjectDetail project = new ProjectDetail(gav);
+
+        Optional<POMInfo> pomInfo = getPomInfo(gav);
+
+        project.setName(getName(gav)); // name
+        project.setDescription(getDescription(pomInfo, gav)); // description
+        setSCMInfo(project, pomInfo); // scmUrl, useExistingBc
+        findExistingBuildConfiguration(project); // bcExists, useExistingBc
+        checkInternallyBuilt(project); // internallyBuilt
+
+        return new ProjectHiearchy(null, false);
+    }
+
+    public static String getName(GAV gav) {
+        return String.format("%s-%s %s", gav.getArtifactId(), gav.getVersion(), UUID.randomUUID()
+                .toString().substring(0, 3));
+    }
+
+    public static String getDescription(Optional<POMInfo> pomInfo, GAV gav) {
+        Optional<String> name = pomInfo.flatMap(p -> p.getName());
+
+        return name.map(n -> String.format("Build Configuration for %s - %s.", gav, n))
+                   .orElse(String.format("Build Configuration for %s.", gav));
+    }
+
+    private Optional<POMInfo> getPomInfo(GAV gav) {
+        Optional<POMInfo> pomInfo = Optional.empty();
+
+        try {
+            pomInfo = pom.getPomInfo(gav);
+        } catch (CommunicationException | PomAnalysisException ex) {
+            log.warn("Failed to get pom for gav " + gav + " from AProx", ex);
+        }
+
+        if (!pomInfo.isPresent()) {
+            try {
+                pomInfo = pom.getPomInfo(scmUrl, revison, gav);
+            } catch (ScmException ex) {
+                log.warn("Failed to get pom for gav " + gav + " from product SCM repository", ex);
+            }
+        }
+
+        return pomInfo;
+    }
+
+    /**
+     * Sets scmUrl and scmRevision
+     */
+    private void setSCMInfo(ProjectDetail project, Optional<POMInfo> pomInfo) {
+        Optional<String> url = pomInfo.flatMap(p -> p.getScmURL());
+        Optional<String> rev = pomInfo.flatMap(p -> p.getScmRevision());
+
+        if(!url.isPresent() || !rev.isPresent()){
+            try {
+                boolean gavInRepository = scm.isGAVInRepository(scmUrl, revison, project.getGav());
+                if(gavInRepository){
+                    if(url.isPresent()){
+                        if(url.get().equals(scmUrl)){
+                            rev = Optional.of(revison);
+                        }
+                    }else{
+                        if(rev.isPresent()){
+                            if(rev.get().equals(revison)){
+                                url = Optional.of(scmUrl);
+                            }
+                        }else{
+                            url = Optional.of(scmUrl);
+                            rev = Optional.of(revison);
+                        }
+                    }
+                }
+            } catch (ScmException ex) {
+                log.warn("Failed to check if GAV " + project.getGav() + " is in repository.", ex);
+            }
+        }
+
+        project.setScmUrl(url.orElse(null));
+        project.setScmRevision(rev.orElse(null));
+    }
+
+    /**
+     * Sets bcExists and useExistingBc
+     * @param project Project with SCM information set.
+     */
+    private void findExistingBuildConfiguration(ProjectDetail project) {
+        if (project.getScmUrl() == null || project.getScmRevision() == null)
+            return;
+
+        try {
+            Optional<BuildConfiguration> found = bcFinder.lookupBcByScm(project.getScmUrl(),
+                    project.getScmRevision());
+            project.setBcExists(found.isPresent());
+            project.setUseExistingBc(found.isPresent());
+        } catch (Exception ex) {
+            log.warn("Failed to lookup existing BC for " + project.getGav(), ex);
+        }
+    }
+
+    /**
+     * Sets internallyBuilt
+     */
+    private void checkInternallyBuilt(ProjectDetail project) {
+        try {
+            Optional<String> bestMatchVersionFor = versionFinder.getBestMatchVersionFor(project
+                    .getGav());
+            project.setInternallyBuilt(bestMatchVersionFor);
+        } catch (CommunicationException ex) {
+            log.warn("Could not obtain best match version for " + project.getGav(), ex);
+            project.setInternallyBuilt(Optional.empty());
+        }
+    }
+}

--- a/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
@@ -154,6 +154,13 @@ public class PomAnalyzerImpl implements PomAnalyzer {
         }
     }
 
+    @Override
+    public Optional<File> getPOMFileForGAV(File pomRepoDir, GAV gav) {
+        return findAllPomFiles(pomRepoDir).stream()
+                .filter(file -> isProjectVersionRefSameAsGAV((new PomPeek(file)).getKey(), gav))
+                .findAny();
+    }
+
     /**
      * Return an existing GAVDependencyTree if present in the map, otherwise create a new GAVDependencyTree
      * and map the GAV to the GAVDependencyTree

--- a/communication/src/main/java/org/jboss/da/communication/pom/api/PomAnalyzer.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/api/PomAnalyzer.java
@@ -43,4 +43,6 @@ public interface PomAnalyzer {
      */
     GAVDependencyTree readRelationships(File pomRepoDir, GAV gav) throws PomAnalysisException;
 
+    public Optional<File> getPOMFileForGAV(File tempDir, GAV gav);
+
 }

--- a/communication/src/main/java/org/jboss/da/communication/scm/api/SCMConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/scm/api/SCMConnector.java
@@ -39,6 +39,20 @@ public interface SCMConnector {
     GAVDependencyTree getDependencyTreeOfRevision(String scmUrl, String revision, GAV gav)
             throws ScmException, PomAnalysisException;
 
+    /**
+     * Returns true when GAV is in given repository.
+     *
+     * @param scmUrl
+     * @param revision
+     * @param gav
+     * @return True when GAV is present in given repository
+     * @throws ScmException When checking out the repository failed
+     */
+    boolean isGAVInRepository(String scmUrl, String revision, GAV gav) throws ScmException;
+
     Optional<MavenProject> getPom(String scmUrl, String revision, String pomPath)
+            throws ScmException;
+
+    public Optional<MavenProject> getPom(String scmUrl, String scmRevision, GAV gav)
             throws ScmException;
 }

--- a/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
@@ -65,4 +65,22 @@ public class SCMConnectorImpl implements SCMConnector {
         return pomAnalyzer.readPom(new File(tempDir, pomPath));
     }
 
+    @Override
+    public boolean isGAVInRepository(String scmUrl, String revision, GAV gav) throws ScmException {
+        // git clone
+        // TODO: hardcoded to git right now
+        File tempDir = scmManager.cloneRepository(SCMType.GIT, scmUrl, revision);
+
+        return pomAnalyzer.getPOMFileForGAV(tempDir, gav).isPresent();
+    }
+
+    @Override
+    public Optional<MavenProject> getPom(String scmUrl, String revision, GAV gav) throws ScmException {
+        // git clone
+        // TODO: hardcoded to git right now
+        File tempDir = scmManager.cloneRepository(SCMType.GIT, scmUrl, revision);
+
+        return pomAnalyzer.getPOMFileForGAV(tempDir, gav)
+                .flatMap(file -> pomAnalyzer.readPom(file));
+    }
 }


### PR DESCRIPTION
When there is log.warn in ProjectHiearchyCreator we can add some functionality in the future to propagate these errors into frontend
```
entity.addError("it doesn't work!");
```