### PR TITLE
Disable SVN test

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
@@ -32,6 +32,7 @@ public class SCMConnectorImpl implements SCMConnector {
             throws ScmException, PomAnalysisException {
         // git clone
         // TODO: hardcoded to git right now
+        // TODO: enable the svn test if svn support is added
         File tempDir = scmManager.cloneRepository(SCMType.GIT, scmUrl, revision);
 
         GAVDependencyTree gavDependencyTree = pomAnalyzer.readRelationships(tempDir, gav);
@@ -43,6 +44,7 @@ public class SCMConnectorImpl implements SCMConnector {
             String pomPath) throws ScmException, PomAnalysisException {
         // git clone
         // TODO: hardcoded to git right now
+        // TODO: enable the svn test if svn support is added
         File tempDir = scmManager.cloneRepository(SCMType.GIT, scmUrl, revision);
 
         GAVDependencyTree gavDependencyTree = pomAnalyzer.readRelationships(tempDir, new File(

--- a/testsuite/src/test/java/org/jboss/da/test/server/scm/SCMTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/server/scm/SCMTest.java
@@ -3,6 +3,7 @@ package org.jboss.da.test.server.scm;
 import org.apache.commons.io.FileUtils;
 import org.jboss.da.scm.impl.SCMClonner;
 import org.jboss.da.scm.api.SCMType;
+import org.junit.Ignore;
 import org.junit.Test;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,6 +46,7 @@ public class SCMTest {
         }
     }
 
+    @Ignore
     @Test
     public void shouldCloneSvnRepository() throws Exception {
         Path tempDir = Files.createTempDirectory("da_temp_svn_checkout");


### PR DESCRIPTION
Given that we are not supporting svn cloning right now, disable svn
tests for now.

We are also disabling it because from time to time the test fails for no
apparent reason. Reducing the amount of noise in our testsuite will be
beneficial.