### PR TITLE
[DA-171] Know if Aprox can analyze a GAV or not.

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/FindGAVDependencyException.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/FindGAVDependencyException.java
@@ -1,0 +1,20 @@
+package org.jboss.da.communication.aprox;
+
+/**
+ * This exception is thrown when the GAV we want to analyze for dependencies
+ * cannot be found on the Aprox server
+ */
+public class FindGAVDependencyException extends Exception {
+
+    public FindGAVDependencyException(String message) {
+        super(message);
+    }
+
+    public FindGAVDependencyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FindGAVDependencyException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
@@ -1,6 +1,7 @@
 package org.jboss.da.communication.aprox.api;
 
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.aprox.model.Repository;
 import org.jboss.da.communication.model.GA;
@@ -23,8 +24,10 @@ public interface AproxConnector {
      * @param gav
      * @return Optional of dependency tree of GAV
      * @throws CommunicationException When there is problem with communication.
+     *         FindGAVDependencyException if the GAV cannot be analyzed
      */
-    Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav) throws CommunicationException;
+    Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav) throws CommunicationException,
+            FindGAVDependencyException;
 
     /**
      * Finds available versions of specific groupId artifactId.
@@ -45,4 +48,13 @@ public interface AproxConnector {
             throws CommunicationException;
 
     List<Repository> getAllRepositoriesFromGroup() throws CommunicationException;
+
+    /**
+     * Finds out if a particular gav is present in the public repository listed
+     * by Aprox
+     * @param gav
+     * @return boolean
+     * @throws CommunicationException if we can't connect to the aprox server
+     */
+    boolean doesGAVExistInPublicRepo(GAV gav) throws CommunicationException;
 }

--- a/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
@@ -22,11 +22,11 @@ public interface AproxConnector {
      * Finds dependency trees of specific GAV
      * 
      * @param gav
-     * @return Optional of dependency tree of GAV
+     * @return Dependency tree of GAV
      * @throws CommunicationException When there is problem with communication.
      *         FindGAVDependencyException if the GAV cannot be analyzed
      */
-    Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav) throws CommunicationException,
+    GAVDependencyTree getDependencyTreeOfGAV(GAV gav) throws CommunicationException,
             FindGAVDependencyException;
 
     /**

--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -2,7 +2,6 @@ package org.jboss.da.communication.aprox.impl;
 
 import org.commonjava.aprox.client.core.Aprox;
 import org.commonjava.aprox.client.core.AproxClientException;
-import org.commonjava.aprox.client.core.AproxClientModule;
 import org.commonjava.aprox.client.core.module.AproxStoresClientModule;
 import org.commonjava.aprox.depgraph.client.DepgraphAproxClientModule;
 import org.commonjava.aprox.model.core.Group;
@@ -16,13 +15,12 @@ import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef;
-import org.eclipse.jgit.lib.RepositoryState;
 import org.jboss.da.common.json.DAConfig;
 import org.jboss.da.common.util.Configuration;
 import org.jboss.da.common.util.ConfigurationParseException;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
-import org.jboss.da.communication.aprox.api.AproxConnector.RepositoryManipulationStatus;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.aprox.model.Repository;
 import org.jboss.da.communication.aprox.model.VersionResponse;
@@ -61,7 +59,12 @@ public class AproxConnectorImpl implements AproxConnector {
 
     @Override
     public Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav)
-            throws CommunicationException {
+            throws CommunicationException, FindGAVDependencyException {
+
+        if (!doesGAVExistInPublicRepo(gav)) {
+            throw new FindGAVDependencyException("Could not find: " + gav
+                    + "in public repo of Aprox");
+        }
 
         DepgraphAproxClientModule mod = new DepgraphAproxClientModule();
         try (Aprox aprox = new Aprox(config.getConfig().getAproxServer() + "/api", mod).connect()) {
@@ -82,7 +85,8 @@ public class AproxConnectorImpl implements AproxConnector {
             GraphExport export = mod.graph(req);
 
             if (export == null || export.getRelationships() == null) {
-                return Optional.empty();
+                // no dependencies found
+                return Optional.of(new GAVDependencyTree(gav));
             }
             return Optional.of(generateGAVDependencyTree(export, gav));
         } catch (AproxClientException | ConfigurationParseException e) {
@@ -204,6 +208,44 @@ public class AproxConnectorImpl implements AproxConnector {
             return repoList;
         } catch (AproxClientException | ConfigurationParseException e) {
             throw new CommunicationException(e);
+        }
+    }
+
+    @Override
+    /**
+     * Implementation note: dcheung tried to initially use HttpURLConnection
+     * and send a 'HEAD' request to the resource. Even though that worked,
+     * for some reason this completely makes Arquillian fail to deploy the testsuite.
+     * For that reason, dcheung switched to using a simple URL object instead with the
+     * try-catch logic.
+     *
+     * No dcheung doesn't usually talks about himself in the third person..
+     */
+    public boolean doesGAVExistInPublicRepo(GAV gav) throws CommunicationException {
+        StringBuilder query = new StringBuilder();
+
+        try {
+            DAConfig config = this.config.getConfig();
+            query.append(config.getAproxServer());
+            query.append("/api/group/public/");
+            query.append(gav.getGroupId().replace(".", "/")).append("/");
+            query.append(gav.getArtifactId()).append('/');
+            query.append(gav.getVersion()).append('/');
+            query.append(gav.getArtifactId()).append("-").append(gav.getVersion()).append(".pom");
+
+            URLConnection connection = new URL(query.toString()).openConnection();
+            try {
+                connection.getInputStream();
+                // if we've reached here, then it means the pom exists
+                return true;
+            } catch (FileNotFoundException e) {
+                // if we've reached here, the resource is not available
+                return false;
+            }
+
+        } catch (IOException | ConfigurationParseException e) {
+            throw new CommunicationException("Failed to establish a connection with Aprox: "
+                    + query.toString(), e);
         }
     }
 

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -42,7 +42,7 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     @Override
     public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException {
         try {
-            return aproxConnector.getDependencyTreeOfGAV(gav);
+            return Optional.of(aproxConnector.getDependencyTreeOfGAV(gav));
         } catch (FindGAVDependencyException e) {
             // TODO: better handle this later in DA-170
             return Optional.empty();

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
@@ -40,7 +41,12 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
 
     @Override
     public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException {
-        return aproxConnector.getDependencyTreeOfGAV(gav);
+        try {
+            return aproxConnector.getDependencyTreeOfGAV(gav);
+        } catch (FindGAVDependencyException e) {
+            // TODO: better handle this later in DA-170
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -1,5 +1,6 @@
 package org.jboss.da.reports.impl;
 
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.CommunicationException;
@@ -85,7 +86,8 @@ public class ReportsGeneratorImplTest {
             Arrays.asList(daUtilDT, daCommonDT)));
 
     private void prepare(boolean whitelisted, boolean blacklisted, List<String> versions,
-            String best, GAVDependencyTree dependencyTree) throws CommunicationException {
+            String best, GAVDependencyTree dependencyTree) throws CommunicationException,
+            FindGAVDependencyException {
         when(versionFinderImpl.getBuiltVersionsFor(daCoreGAV)).thenReturn(versions);
         when(versionFinderImpl.lookupBuiltVersions(daCoreGAV)).thenReturn(
                 new VersionLookupResult(Optional.ofNullable(best), versions));
@@ -99,7 +101,7 @@ public class ReportsGeneratorImplTest {
                 Optional.ofNullable(dependencyTree));
     }
 
-    private void prepareMulti() throws CommunicationException {
+    private void prepareMulti() throws CommunicationException, FindGAVDependencyException {
         prepare(false, false, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
         when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(
                 Optional.ofNullable(daCoreDT));
@@ -132,8 +134,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testNonExistingGAV() throws CommunicationException {
-        when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenReturn(Optional.empty());
+    public void testNonExistingGAV() throws CommunicationException, FindGAVDependencyException {
+        when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenThrow(FindGAVDependencyException.class);
 
         Optional<ArtifactReport> report = generator.getReport(daGAV);
 
@@ -141,7 +143,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testNonListedNoBestMatchGAV() throws CommunicationException {
+    public void testNonListedNoBestMatchGAV() throws CommunicationException,
+            FindGAVDependencyException {
         prepare(false, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -156,7 +159,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testWhiteListedNoBestMatchGAV() throws CommunicationException {
+    public void testWhiteListedNoBestMatchGAV() throws CommunicationException,
+            FindGAVDependencyException {
         prepare(true, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -170,7 +174,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testBlackListedBestMatchGAV() throws CommunicationException {
+    public void testBlackListedBestMatchGAV() throws CommunicationException,
+            FindGAVDependencyException {
         prepare(false, true, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -185,7 +190,7 @@ public class ReportsGeneratorImplTest {
 
     @Test
     public void testArtifactReportShouldNotHaveNullValuesInAvailableVersionsWhenBestMatchVersionIsNull()
-            throws CommunicationException {
+            throws CommunicationException, FindGAVDependencyException {
         prepare(false, false, daCoreVersionsBest, null, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -195,7 +200,7 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testGetMultipleReport() throws CommunicationException {
+    public void testGetMultipleReport() throws CommunicationException, FindGAVDependencyException {
         prepareMulti();
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -97,14 +97,12 @@ public class ReportsGeneratorImplTest {
                 Optional.ofNullable(best));
         when(blackArtifactService.isArtifactPresent(daCoreGAV)).thenReturn(blacklisted);
         when(whiteArtifactService.isArtifactPresent(daCoreGAV)).thenReturn(whitelisted);
-        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(
-                Optional.ofNullable(dependencyTree));
+        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(dependencyTree);
     }
 
     private void prepareMulti() throws CommunicationException, FindGAVDependencyException {
         prepare(false, false, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
-        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(
-                Optional.ofNullable(daCoreDT));
+        when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(daCoreDT);
 
         when(versionFinderImpl.getBuiltVersionsFor(daUtilGAV)).thenReturn(daCoreVersionsBest);
         when(versionFinderImpl.lookupBuiltVersions(daUtilGAV)).thenReturn(

--- a/testsuite/src/test/java/org/jboss/da/test/client/rest/reports/RestApiReportsRemoteTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/client/rest/reports/RestApiReportsRemoteTest.java
@@ -59,7 +59,6 @@ public class RestApiReportsRemoteTest extends AbstractRestReportsTest {
     }
 
     @Test
-    @Ignore
     public void testReportWithoutDependencies() throws Exception {
         ClientResponse<String> responseWith = assertResponseForRequest(PATH_REPORTS_GAV,
                 "withDependencies");

--- a/testsuite/src/test/java/org/jboss/da/test/server/communication/AproxRemoteTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/server/communication/AproxRemoteTest.java
@@ -3,15 +3,14 @@ package org.jboss.da.test.server.communication;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.scm.ScmException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GA;
 import org.jboss.da.communication.model.GAV;
-import org.jboss.da.communication.pom.PomAnalysisException;
 import org.jboss.da.test.ArquillianDeploymentFactory;
 import org.jboss.da.test.ArquillianDeploymentFactory.DepType;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -53,7 +52,7 @@ public class AproxRemoteTest {
     }
 
     @Test
-    public void testGetCorrectDependencies() throws CommunicationException {
+    public void testGetCorrectDependencies() throws CommunicationException, FindGAVDependencyException {
         GAV gav = new GAV("xom", "xom", "1.2.5");
         Optional<GAVDependencyTree> tree = aproxConnector.getDependencyTreeOfGAV(gav);
 
@@ -66,11 +65,26 @@ public class AproxRemoteTest {
         assertEquals(expectedDependencyGAV, receivedDependencyGAV);
     }
 
-    @Test
-    public void testNoGAVInRepository() throws CommunicationException {
+    @Test(expected = FindGAVDependencyException.class)
+    public void testNoGAVInRepository() throws CommunicationException, FindGAVDependencyException {
         GAV gav = new GAV("do", "not-exist", "1.0");
-        Optional<GAVDependencyTree> tree = aproxConnector.getDependencyTreeOfGAV(gav);
-        assertFalse(tree.isPresent());
+        aproxConnector.getDependencyTreeOfGAV(gav);
+    }
+
+    @Test
+    public void noDependenciesForGAV() throws CommunicationException, FindGAVDependencyException {
+        GAV gav = new GAV("org.scala-lang", "scala-library", "2.11.7");
+        Optional<GAVDependencyTree> reply = aproxConnector.getDependencyTreeOfGAV(gav);
+        assertTrue(reply.get().getDependencies().isEmpty());
+    }
+
+    @Test
+    public void findIfGAVInPublicRepo() throws CommunicationException {
+        GAV not_exist = new GAV("do", "not-exist", "2.0");
+        assertFalse(aproxConnector.doesGAVExistInPublicRepo(not_exist));
+
+        GAV exist = new GAV("xom", "xom", "1.2.5");
+        assertTrue(aproxConnector.doesGAVExistInPublicRepo(exist));
     }
 
 }

--- a/testsuite/src/test/java/org/jboss/da/test/server/communication/AproxRemoteTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/server/communication/AproxRemoteTest.java
@@ -54,12 +54,12 @@ public class AproxRemoteTest {
     @Test
     public void testGetCorrectDependencies() throws CommunicationException, FindGAVDependencyException {
         GAV gav = new GAV("xom", "xom", "1.2.5");
-        Optional<GAVDependencyTree> tree = aproxConnector.getDependencyTreeOfGAV(gav);
+        GAVDependencyTree tree = aproxConnector.getDependencyTreeOfGAV(gav);
 
         Set<String> expectedDependencyGAV = new HashSet<>(
                 Arrays.asList(new String[] {"xalan:xalan:2.7.0", "xerces:xercesImpl:2.8.0", "xml-apis:xml-apis:1.3.03"}));
 
-        Set<String> receivedDependencyGAV = tree.get().getDependencies().stream()
+        Set<String> receivedDependencyGAV = tree.getDependencies().stream()
                 .map(f -> f.getGav().toString()).collect(Collectors.toSet());
 
         assertEquals(expectedDependencyGAV, receivedDependencyGAV);
@@ -74,8 +74,8 @@ public class AproxRemoteTest {
     @Test
     public void noDependenciesForGAV() throws CommunicationException, FindGAVDependencyException {
         GAV gav = new GAV("org.scala-lang", "scala-library", "2.11.7");
-        Optional<GAVDependencyTree> reply = aproxConnector.getDependencyTreeOfGAV(gav);
-        assertTrue(reply.get().getDependencies().isEmpty());
+        GAVDependencyTree reply = aproxConnector.getDependencyTreeOfGAV(gav);
+        assertTrue(reply.getDependencies().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Previously, when we asked Aprox to analyze a GAV for its dependencies,
we received the same result whether the GAV was:

- not present in Aprox and therefore cannot be analyzed
- present in Aprox and having no compile dependencies.

This commit fixes it by first checking if Aprox has the requested GAV in
its public repository. If yes, then proceed to the actual analysis.

However if the GAV is not in the public repository, a
`FindGAVDependencyException` is thrown.

Right now the `DependencyTreeGeneratorImpl` just catches the new
exception and returns an `Optional.empty()`. This will be really fixed
in DA-170 in another commit.

The JUnit tests are also adjusted to test/adapt for the new behaviour.