### PR TITLE
Try to parse the pom.xmls and not fail if we can't

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
@@ -40,9 +40,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jboss.da.communication.CommunicationException;
+import org.slf4j.Logger;
 
 @ApplicationScoped
 public class PomAnalyzerImpl implements PomAnalyzer {
+
+    @Inject
+    private Logger log;
 
     @Inject
     private PomReader pomReader;
@@ -244,14 +248,19 @@ public class PomAnalyzerImpl implements PomAnalyzer {
 
         for (File pomFile : poms) {
             PomPeek peek = new PomPeek(pomFile);
-            projectVersionRefs.put(pomFile.getParentFile().getAbsoluteFile(), peek.getKey());
 
-            String path = ArtifactPathUtils.formatArtifactPath(peek.getKey().asPomArtifact(), carto
-                    .getGalley().getTypeMapper());
+            try {
+                String path = ArtifactPathUtils.formatArtifactPath(peek.getKey().asPomArtifact(),
+                        carto.getGalley().getTypeMapper());
 
-            File f = new File(tempDir, path);
-            f.getParentFile().mkdirs();
-            FileUtils.copyFile(pomFile, f);
+                File f = new File(tempDir, path);
+                f.getParentFile().mkdirs();
+                FileUtils.copyFile(pomFile, f);
+
+                projectVersionRefs.put(pomFile.getParentFile().getAbsoluteFile(), peek.getKey());
+            } catch (NullPointerException ex) {
+                log.warn("Could not parse " + pomFile.getAbsolutePath());
+            }
         }
         return projectVersionRefs;
     }

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -2,9 +2,6 @@ package org.jboss.da.rest.reports;
 
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.communication.CommunicationException;
-import org.jboss.da.communication.aprox.api.AproxConnector;
-import org.jboss.da.communication.aprox.api.AproxConnector.RepositoryManipulationStatus;
-import org.jboss.da.communication.aprox.model.Repository;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.PomAnalysisException;
 import org.jboss.da.listings.api.service.BlackArtifactService;
@@ -14,7 +11,6 @@ import org.jboss.da.reports.api.ReportsGenerator;
 import org.jboss.da.reports.api.SCMLocator;
 import org.jboss.da.reports.api.VersionLookupResult;
 import org.jboss.da.reports.backend.api.VersionFinder;
-import org.jboss.da.rest.listings.model.SuccessResponse;
 import org.jboss.da.rest.model.ErrorMessage;
 import org.jboss.da.rest.reports.model.LookupReport;
 import org.jboss.da.rest.reports.model.Report;
@@ -22,8 +18,6 @@ import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;


### PR DESCRIPTION
Some pom.xmls that we analyze have issues which cause the analysis of
_all_ the pom.xmls to fail.

This commit instead attempts to ignore the failed pom.xmls analyzed, and
use only the ones that the analyzer was able to successfully parse.

If a pom.xml was not able to be analyzed, we'll log it.

Unrelated, but this commit also removes some unused imports in
`Reports.java`