### PR TITLE
[DA-170] Status field for bcg endpoint 

### DIFF
--- a/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
@@ -6,6 +6,7 @@ import org.jboss.da.bc.api.BuildConfigurationGenerator;
 import org.jboss.da.bc.backend.api.Finalizer;
 import org.jboss.da.bc.backend.api.POMInfo;
 import org.jboss.da.bc.backend.api.POMInfoGenerator;
+import org.jboss.da.bc.model.DependencyAnalysisStatus;
 import org.jboss.da.bc.model.GeneratorEntity;
 import org.jboss.da.bc.model.ProjectDetail;
 import org.jboss.da.bc.model.ProjectHiearchy;
@@ -63,6 +64,8 @@ public class BuildConfigurationGeneratorImpl implements BuildConfigurationGenera
         ge.getToplevelBc().setDependencies(
                 Optional.of(nextLevel.processDependencies(ge, deps.getDependencies())));
 
+        // the top level bc has had its dependencies analyzed
+        ge.getToplevelBc().setAnalysisStatus(DependencyAnalysisStatus.ANALYZED);
         return ge;
     }
 

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/DependencyAnalysisStatus.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/DependencyAnalysisStatus.java
@@ -1,0 +1,5 @@
+package org.jboss.da.bc.model;
+
+public enum DependencyAnalysisStatus {
+    FAILED, ANALYZED, NOT_ANALYSED
+}

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectHiearchy.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectHiearchy.java
@@ -18,6 +18,10 @@ public class ProjectHiearchy {
 
     @Getter
     @Setter
+    private DependencyAnalysisStatus analysisStatus = DependencyAnalysisStatus.NOT_ANALYSED;
+
+    @Getter
+    @Setter
     @JsonUnwrapped
     private ProjectDetail project;
 

--- a/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
@@ -3,6 +3,7 @@ package org.jboss.da.bc;
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.bc.api.BuildConfigurationGenerator;
 import org.jboss.da.bc.model.BuildConfiguration;
+import org.jboss.da.bc.model.DependencyAnalysisStatus;
 import org.jboss.da.bc.model.EntryEntity;
 import org.jboss.da.bc.model.FinishResponse;
 import org.jboss.da.bc.model.GeneratorEntity;
@@ -132,6 +133,7 @@ public class BuildConfigurationsProduct {
         bc.setScmUrl(p.getScmUrl());
         bc.setSelected(ph.isSelected());
         bc.setUseExistingBc(p.isUseExistingBc());
+        bc.setAnalysisStatus(ph.getAnalysisStatus());
 
         List<BuildConfiguration> dependencies = ph.getDependencies()
                 .map(deps -> deps.stream()
@@ -179,6 +181,9 @@ public class BuildConfigurationsProduct {
             ph.setDependencies(Optional.of(bc.getDependencies().stream()
                     .map(dep -> toProjectHiearchy(dep)).collect(Collectors.toSet())));
         }
+
+        ph.setAnalysisStatus(bc.getAnalysisStatus());
+
         return ph;
     }
 }

--- a/bc-rest/src/main/java/org/jboss/da/bc/model/BuildConfiguration.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/model/BuildConfiguration.java
@@ -21,6 +21,10 @@ public class BuildConfiguration {
 
     @Getter
     @Setter
+    protected DependencyAnalysisStatus analysisStatus;
+
+    @Getter
+    @Setter
     protected String scmUrl;
 
     @Getter

--- a/communication/src/main/java/org/jboss/da/communication/aprox/FindGAVDependencyException.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/FindGAVDependencyException.java
@@ -1,0 +1,20 @@
+package org.jboss.da.communication.aprox;
+
+/**
+ * This exception is thrown when the GAV we want to analyze for dependencies
+ * cannot be found on the Aprox server
+ */
+public class FindGAVDependencyException extends Exception {
+
+    public FindGAVDependencyException(String message) {
+        super(message);
+    }
+
+    public FindGAVDependencyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FindGAVDependencyException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
@@ -1,6 +1,7 @@
 package org.jboss.da.communication.aprox.api;
 
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.aprox.model.Repository;
 import org.jboss.da.communication.model.GA;
@@ -23,8 +24,10 @@ public interface AproxConnector {
      * @param gav
      * @return Optional of dependency tree of GAV
      * @throws CommunicationException When there is problem with communication.
+     *         FindGAVDependencyException if the GAV cannot be analyzed
      */
-    Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav) throws CommunicationException;
+    Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav) throws CommunicationException,
+            FindGAVDependencyException;
 
     /**
      * Finds available versions of specific groupId artifactId.
@@ -45,4 +48,13 @@ public interface AproxConnector {
             throws CommunicationException;
 
     List<Repository> getAllRepositoriesFromGroup() throws CommunicationException;
+
+    /**
+     * Finds out if a particular gav is present in the public repository listed
+     * by Aprox
+     * @param gav
+     * @return boolean
+     * @throws CommunicationException if we can't connect to the aprox server
+     */
+    boolean doesGAVExistInPublicRepo(GAV gav) throws CommunicationException;
 }

--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -63,7 +63,7 @@ public class AproxConnectorImpl implements AproxConnector {
 
         if (!doesGAVExistInPublicRepo(gav)) {
             throw new FindGAVDependencyException("Could not find: " + gav
-                    + "in public repo of Aprox");
+                    + " in public repo of Aprox");
         }
 
         DepgraphAproxClientModule mod = new DepgraphAproxClientModule();

--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -2,7 +2,6 @@ package org.jboss.da.communication.aprox.impl;
 
 import org.commonjava.aprox.client.core.Aprox;
 import org.commonjava.aprox.client.core.AproxClientException;
-import org.commonjava.aprox.client.core.AproxClientModule;
 import org.commonjava.aprox.client.core.module.AproxStoresClientModule;
 import org.commonjava.aprox.depgraph.client.DepgraphAproxClientModule;
 import org.commonjava.aprox.model.core.Group;
@@ -16,13 +15,12 @@ import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef;
-import org.eclipse.jgit.lib.RepositoryState;
 import org.jboss.da.common.json.DAConfig;
 import org.jboss.da.common.util.Configuration;
 import org.jboss.da.common.util.ConfigurationParseException;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
-import org.jboss.da.communication.aprox.api.AproxConnector.RepositoryManipulationStatus;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.aprox.model.Repository;
 import org.jboss.da.communication.aprox.model.VersionResponse;
@@ -61,7 +59,12 @@ public class AproxConnectorImpl implements AproxConnector {
 
     @Override
     public Optional<GAVDependencyTree> getDependencyTreeOfGAV(GAV gav)
-            throws CommunicationException {
+            throws CommunicationException, FindGAVDependencyException {
+
+        if (!doesGAVExistInPublicRepo(gav)) {
+            throw new FindGAVDependencyException("Could not find: " + gav
+                    + "in public repo of Aprox");
+        }
 
         DepgraphAproxClientModule mod = new DepgraphAproxClientModule();
         try (Aprox aprox = new Aprox(config.getConfig().getAproxServer() + "/api", mod).connect()) {
@@ -82,6 +85,7 @@ public class AproxConnectorImpl implements AproxConnector {
             GraphExport export = mod.graph(req);
 
             if (export == null || export.getRelationships() == null) {
+                // no dependencies found
                 return Optional.empty();
             }
             return Optional.of(generateGAVDependencyTree(export, gav));
@@ -204,6 +208,44 @@ public class AproxConnectorImpl implements AproxConnector {
             return repoList;
         } catch (AproxClientException | ConfigurationParseException e) {
             throw new CommunicationException(e);
+        }
+    }
+
+    @Override
+    /**
+     * Implementation note: dcheung tried to initially use HttpURLConnection
+     * and send a 'HEAD' request to the resource. Even though that worked,
+     * for some reason this completely makes Arquillian fail to deploy the testsuite.
+     * For that reason, dcheung switched to using a simple URL object instead with the
+     * try-catch logic.
+     *
+     * No dcheung doesn't usually talks about himself in the third person..
+     */
+    public boolean doesGAVExistInPublicRepo(GAV gav) throws CommunicationException {
+        StringBuilder query = new StringBuilder();
+
+        try {
+            DAConfig config = this.config.getConfig();
+            query.append(config.getAproxServer());
+            query.append("/api/group/public/");
+            query.append(gav.getGroupId().replace(".", "/")).append("/");
+            query.append(gav.getArtifactId()).append('/');
+            query.append(gav.getVersion()).append('/');
+            query.append(gav.getArtifactId()).append("-").append(gav.getVersion()).append(".pom");
+
+            URLConnection connection = new URL(query.toString()).openConnection();
+            try {
+                connection.getInputStream();
+                // if we've reached here, then it means the pom exists
+                return true;
+            } catch (FileNotFoundException e) {
+                // if we've reached here, the resource is not available
+                return false;
+            }
+
+        } catch (IOException | ConfigurationParseException e) {
+            throw new CommunicationException("Failed to establish a connection with Aprox: "
+                    + query.toString(), e);
         }
     }
 

--- a/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
@@ -2,6 +2,7 @@ package org.jboss.da.reports.api;
 
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.PomAnalysisException;
 
@@ -35,6 +36,7 @@ public interface ReportsGenerator {
      * @return Created report or empty Optional if the requested GAV was not found in the repository
      * @throws CommunicationException when there is a problem with communication with remote services
      */
-    public Optional<ArtifactReport> getReport(GAV gav) throws CommunicationException;
+    public ArtifactReport getReport(GAV gav) throws CommunicationException,
+            FindGAVDependencyException;
 
 }

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
@@ -3,6 +3,7 @@ package org.jboss.da.reports.backend.api;
 import java.util.Optional;
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.PomAnalysisException;
@@ -17,7 +18,8 @@ public interface DependencyTreeGenerator {
     public GAVDependencyTree getDependencyTree(SCMLocator scml) throws ScmException,
             PomAnalysisException;
 
-    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException;
+    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException,
+            FindGAVDependencyException;
 
     public GAVDependencyTree getDependencyTree(String url, String revision, GAV gav)
             throws ScmException, PomAnalysisException;
@@ -26,7 +28,7 @@ public interface DependencyTreeGenerator {
             PomAnalysisException;
 
     public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav)
-            throws CommunicationException;
+            throws CommunicationException, FindGAVDependencyException;
 
     public GAVToplevelDependencies getToplevelDependencies(String url, String revision, GAV gav)
             throws ScmException, PomAnalysisException;

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -40,13 +40,9 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     }
 
     @Override
-    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException {
-        try {
-            return aproxConnector.getDependencyTreeOfGAV(gav);
-        } catch (FindGAVDependencyException e) {
-            // TODO: better handle this later in DA-170
-            return Optional.empty();
-        }
+    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException,
+            FindGAVDependencyException {
+        return aproxConnector.getDependencyTreeOfGAV(gav);
     }
 
     @Override
@@ -63,7 +59,7 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     }
 
     @Override
-    public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav) throws CommunicationException {
+    public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav) throws CommunicationException, FindGAVDependencyException {
         return getDependencyTree(gav).map(tree -> treeToToplevel(tree));
     }
 

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
@@ -40,7 +41,12 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
 
     @Override
     public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException {
-        return aproxConnector.getDependencyTreeOfGAV(gav);
+        try {
+            return aproxConnector.getDependencyTreeOfGAV(gav);
+        } catch (FindGAVDependencyException e) {
+            // TODO: better handle this later in DA-170
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
@@ -1,6 +1,7 @@
 package org.jboss.da.reports.impl;
 
 import org.apache.maven.scm.ScmException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.CommunicationException;
 import org.jboss.da.communication.model.GAV;
@@ -71,23 +72,23 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
     }
 
     @Override
-    public Optional<ArtifactReport> getReport(GAV gav) throws CommunicationException {
+    public ArtifactReport getReport(GAV gav) throws CommunicationException,
+            FindGAVDependencyException {
         if (gav == null)
             throw new IllegalArgumentException("GAV can't be null");
 
         Optional<GAVDependencyTree> dt = dependencyTreeGenerator.getDependencyTree(gav);
 
-        if (!dt.isPresent())
-            return Optional.empty();
-
         Set<GAVDependencyTree> nodesVisited = new HashSet<>();
         VersionLookupResult result = versionFinderImpl.lookupBuiltVersions(gav);
         ArtifactReport report = toArtifactReport(gav, result);
-        nodesVisited.add(dt.get());
 
-        addDependencyReports(report, dt.get().getDependencies(), nodesVisited);
+        if (dt.isPresent()) {
+            nodesVisited.add(dt.get());
+            addDependencyReports(report, dt.get().getDependencies(), nodesVisited);
+        }
 
-        return Optional.of(report);
+        return report;
     }
 
     private ArtifactReport toArtifactReport(GAV gav, VersionLookupResult result) {

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -1,5 +1,6 @@
 package org.jboss.da.reports.impl;
 
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.CommunicationException;
@@ -85,7 +86,8 @@ public class ReportsGeneratorImplTest {
             Arrays.asList(daUtilDT, daCommonDT)));
 
     private void prepare(boolean whitelisted, boolean blacklisted, List<String> versions,
-            String best, GAVDependencyTree dependencyTree) throws CommunicationException {
+            String best, GAVDependencyTree dependencyTree) throws CommunicationException,
+            FindGAVDependencyException {
         when(versionFinderImpl.getBuiltVersionsFor(daCoreGAV)).thenReturn(versions);
         when(versionFinderImpl.lookupBuiltVersions(daCoreGAV)).thenReturn(
                 new VersionLookupResult(Optional.ofNullable(best), versions));
@@ -99,7 +101,7 @@ public class ReportsGeneratorImplTest {
                 Optional.ofNullable(dependencyTree));
     }
 
-    private void prepareMulti() throws CommunicationException {
+    private void prepareMulti() throws CommunicationException, FindGAVDependencyException {
         prepare(false, false, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
         when(aproxClient.getDependencyTreeOfGAV(daCoreGAV)).thenReturn(
                 Optional.ofNullable(daCoreDT));
@@ -132,8 +134,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testNonExistingGAV() throws CommunicationException {
-        when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenReturn(Optional.empty());
+    public void testNonExistingGAV() throws CommunicationException, FindGAVDependencyException {
+        when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenThrow(FindGAVDependencyException.class);
 
         Optional<ArtifactReport> report = generator.getReport(daGAV);
 
@@ -141,7 +143,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testNonListedNoBestMatchGAV() throws CommunicationException {
+    public void testNonListedNoBestMatchGAV() throws CommunicationException,
+            FindGAVDependencyException {
         prepare(false, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -156,7 +159,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testWhiteListedNoBestMatchGAV() throws CommunicationException {
+    public void testWhiteListedNoBestMatchGAV() throws CommunicationException,
+            FindGAVDependencyException {
         prepare(true, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -170,7 +174,8 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testBlackListedBestMatchGAV() throws CommunicationException {
+    public void testBlackListedBestMatchGAV() throws CommunicationException,
+            FindGAVDependencyException {
         prepare(false, true, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -185,7 +190,7 @@ public class ReportsGeneratorImplTest {
 
     @Test
     public void testArtifactReportShouldNotHaveNullValuesInAvailableVersionsWhenBestMatchVersionIsNull()
-            throws CommunicationException {
+            throws CommunicationException, FindGAVDependencyException {
         prepare(false, false, daCoreVersionsBest, null, daCoreNoDT);
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();
@@ -195,7 +200,7 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test
-    public void testGetMultipleReport() throws CommunicationException {
+    public void testGetMultipleReport() throws CommunicationException, FindGAVDependencyException {
         prepareMulti();
 
         ArtifactReport report = generator.getReport(daCoreGAV).get();

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -129,17 +129,15 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNullGAV() throws CommunicationException {
+    public void testNullGAV() throws CommunicationException, FindGAVDependencyException {
         generator.getReport(null);
     }
 
-    @Test
+    @Test(expected = FindGAVDependencyException.class)
     public void testNonExistingGAV() throws CommunicationException, FindGAVDependencyException {
         when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenThrow(FindGAVDependencyException.class);
 
-        Optional<ArtifactReport> report = generator.getReport(daGAV);
-
-        assertFalse(report.isPresent());
+        ArtifactReport report = generator.getReport(daGAV);
     }
 
     @Test
@@ -147,7 +145,7 @@ public class ReportsGeneratorImplTest {
             FindGAVDependencyException {
         prepare(false, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
@@ -163,7 +161,7 @@ public class ReportsGeneratorImplTest {
             FindGAVDependencyException {
         prepare(true, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
@@ -178,7 +176,7 @@ public class ReportsGeneratorImplTest {
             FindGAVDependencyException {
         prepare(false, true, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
@@ -193,7 +191,7 @@ public class ReportsGeneratorImplTest {
             throws CommunicationException, FindGAVDependencyException {
         prepare(false, false, daCoreVersionsBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertFalse(report.getBestMatchVersion().isPresent());
         assertFalse(report.getAvailableVersions().stream().anyMatch(version -> version == null));
@@ -203,7 +201,7 @@ public class ReportsGeneratorImplTest {
     public void testGetMultipleReport() throws CommunicationException, FindGAVDependencyException {
         prepareMulti();
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());

--- a/testsuite/src/test/java/org/jboss/da/test/server/communication/AproxRemoteTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/server/communication/AproxRemoteTest.java
@@ -3,15 +3,14 @@ package org.jboss.da.test.server.communication;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.maven.scm.ScmException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.api.AproxConnector;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GA;
 import org.jboss.da.communication.model.GAV;
-import org.jboss.da.communication.pom.PomAnalysisException;
 import org.jboss.da.test.ArquillianDeploymentFactory;
 import org.jboss.da.test.ArquillianDeploymentFactory.DepType;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -53,7 +52,7 @@ public class AproxRemoteTest {
     }
 
     @Test
-    public void testGetCorrectDependencies() throws CommunicationException {
+    public void testGetCorrectDependencies() throws CommunicationException, FindGAVDependencyException {
         GAV gav = new GAV("xom", "xom", "1.2.5");
         Optional<GAVDependencyTree> tree = aproxConnector.getDependencyTreeOfGAV(gav);
 
@@ -66,11 +65,19 @@ public class AproxRemoteTest {
         assertEquals(expectedDependencyGAV, receivedDependencyGAV);
     }
 
-    @Test
-    public void testNoGAVInRepository() throws CommunicationException {
+    @Test(expected = FindGAVDependencyException.class)
+    public void testNoGAVInRepository() throws CommunicationException, FindGAVDependencyException {
         GAV gav = new GAV("do", "not-exist", "1.0");
-        Optional<GAVDependencyTree> tree = aproxConnector.getDependencyTreeOfGAV(gav);
-        assertFalse(tree.isPresent());
+        aproxConnector.getDependencyTreeOfGAV(gav);
+    }
+
+    @Test
+    public void findIfGAVInPublicRepo() throws CommunicationException {
+        GAV not_exist = new GAV("do", "not-exist", "2.0");
+        assertFalse(aproxConnector.doesGAVExistInPublicRepo(not_exist));
+
+        GAV exist = new GAV("xom", "xom", "1.2.5");
+        assertTrue(aproxConnector.doesGAVExistInPublicRepo(exist));
     }
 
 }


### PR DESCRIPTION
When using the bcg endpoint to analyze dependencies, it would be nice to
also get a status of how the dependencies went. Did the analysis
succeeded, failed, or has not been done yet?

In the longer term, this status field could be used in PNC UI to throw
relevant notifications to the user.

This commit builds on DA-171 which adds a way to know if Aprox could not
analyse a particular GAV. DA-171 is required to know whether the
analysis of the GAV failed, or the GAV had no dependencies. Previously
the two cases mentioned above could not be distinguished.

We add the status field by first creating an enum
(`DependencyAnalysisStatus`), and adding the status field to the backend
DAO `ProjectHierarchy` and the frontend DAO `BuildConfiguration`.

Most of the other changes occur in `ProjectHiearchyCreator` where we use
the new status field to know if we need to analyze a dependency or not.

The status field is populated in `getDependencies` method in
`ProjectHiearchyCreator`.

The rest of the changes is on the methods converting a `ProjectHiearchy`
to a `BuildConfiguration`, and vice-versa.

Thanks to @jsenko for his UI fix on PNC: https://github.com/project-ncl/pnc/pull/685