### PR TITLE
[DA-179] bump versions of galley and cartographer

### DIFF
--- a/communication/pom.xml
+++ b/communication/pom.xml
@@ -74,6 +74,10 @@
             <groupId>org.commonjava.maven.galley</groupId>
             <artifactId>galley-maven</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.commonjava.maven.galley</groupId>
+            <artifactId>galley-cdi-embedder</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/communication/src/main/java/org/jboss/da/communication/CartographerProducer.java
+++ b/communication/src/main/java/org/jboss/da/communication/CartographerProducer.java
@@ -7,22 +7,10 @@ import org.commonjava.cartographer.spi.graph.discover.DiscoverySourceManager;
 import org.commonjava.maven.atlas.graph.RelationshipGraphFactory;
 import org.commonjava.maven.atlas.graph.spi.neo4j.FileNeo4jConnectionFactory;
 import org.commonjava.maven.galley.cache.FileCacheProviderConfig;
-import org.commonjava.maven.galley.maven.ArtifactManager;
-import org.commonjava.maven.galley.maven.parse.MavenPomReader;
-import org.commonjava.maven.galley.spi.auth.PasswordManager;
-import org.commonjava.maven.galley.spi.cache.CacheProvider;
-import org.commonjava.maven.galley.spi.event.FileEventManager;
-import org.commonjava.maven.galley.spi.io.PathGenerator;
-import org.commonjava.maven.galley.spi.io.TransferDecorator;
-import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
-import org.commonjava.maven.galley.spi.transport.LocationExpander;
-import org.commonjava.maven.galley.spi.transport.LocationResolver;
-import org.commonjava.maven.galley.transport.htcli.Http;
 import org.jboss.da.communication.pom.qualifier.DACartographerCore;
 import javax.enterprise.inject.Produces;
 import java.io.File;
 import java.io.IOException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Class used to inject null to '@Injects' in cartographer
@@ -41,27 +29,7 @@ public class CartographerProducer {
     }
 
     @Produces
-    public Http getHttp() {
-        return null;
-    }
-
-    @Produces
-    public LocationExpander getLocationExpander() {
-        return null;
-    }
-
-    @Produces
-    public ArtifactManager getArtifactManager() {
-        return null;
-    }
-
-    @Produces
     public DiscoverySourceManager getDiscoverySourceManager() {
-        return null;
-    }
-
-    @Produces
-    public LocationResolver getLocationResolver() {
         return null;
     }
 
@@ -71,47 +39,8 @@ public class CartographerProducer {
     }
 
     @Produces
-    public MavenPomReader getMavenPomReader() {
-        return null;
-    }
-
-    @Produces
     public FileCacheProviderConfig getFileCacheProviderConfig() {
-        return null;
-    }
-
-    @Produces
-    public NotFoundCache getNotFoundCache() {
-        return null;
-    }
-
-    @Produces
-    public CacheProvider getCacheProvider() {
-        return null;
-    }
-
-    @Produces
-    public TransferDecorator getTransferDecorator() {
-        return null;
-    }
-
-    @Produces
-    public ObjectMapper getObjectMapper() {
-        return null;
-    }
-
-    @Produces
-    public PathGenerator getPathGenerator() {
-        return null;
-    }
-
-    @Produces
-    public FileEventManager getFileEventManager() {
-        return null;
-    }
-
-    @Produces
-    public PasswordManager getPasswordManager() {
-        return null;
+        FileCacheProviderConfig fcpc = new FileCacheProviderConfig(new File("random"));
+        return fcpc;
     }
 }

--- a/communication/src/main/java/org/jboss/da/communication/pom/qualifier/DACartographerCore.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/qualifier/DACartographerCore.java
@@ -1,5 +1,6 @@
 package org.jboss.da.communication.pom.qualifier;
 
+import java.lang.annotation.ElementType;
 import javax.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,5 +13,6 @@ import java.lang.annotation.Target;
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
 public @interface DACartographerCore {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <version.arquillian>1.1.8.Final</version.arquillian>
         <version.shrinkwrap.resolver>2.1.1</version.shrinkwrap.resolver>
         <version.aether>0.9.0.M2</version.aether>
+        <version.galley>0.10.2</version.galley>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jboss.bom.version>6.3.2.GA</jboss.bom.version>
@@ -164,7 +165,7 @@
             <dependency>
                 <groupId>org.commonjava.aprox</groupId>
                 <artifactId>aprox-depgraph-client-java</artifactId>
-                <version>0.24.0</version>
+                <version>0.25.1</version>
             </dependency>
 
 
@@ -218,12 +219,17 @@
             <dependency>
                 <groupId>org.commonjava.maven.cartographer</groupId>
                 <artifactId>cartographer</artifactId>
-                <version>0.10.0</version>
+                <version>0.10.2</version>
             </dependency>
             <dependency>
                 <groupId>org.commonjava.maven.galley</groupId>
                 <artifactId>galley-maven</artifactId>
-                <version>0.10.0</version>
+                <version>${version.galley}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.commonjava.maven.galley</groupId>
+                <artifactId>galley-cdi-embedder</artifactId>
+                <version>${version.galley}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/src/test/java/org/jboss/da/test/client/rest/reports/BugReporoducerRemoteTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/client/rest/reports/BugReporoducerRemoteTest.java
@@ -34,7 +34,6 @@ public class BugReporoducerRemoteTest extends AbstractRestReportsTest {
     }
 
     @Test
-    @Ignore
     public void testDA179() throws Exception {
         String gavNonexisting = "pnc-3de7ed5";
         File jsonRequestFile = getJsonRequestFile(PATH_SCM, gavNonexisting);


### PR DESCRIPTION
Galley in version 0.10.3 fixed issue with NPE.
We had to bump also version of cartographer and add galley-cdi-embedder
so there are no missing or ambiguous dependencies.