### PR TITLE
[DA-170] Status field for bcg endpoint

### DIFF
--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
@@ -56,7 +56,7 @@ public class FinalizerImpl implements Finalizer {
     private Integer create(ProjectHiearchy hiearchy, Set<Integer> allDependencyIds) throws Exception {
         Set<Integer> nextLevelDependencyIds = new HashSet<>();
 
-        for (ProjectHiearchy dep : hiearchy.getDependencies().orElseGet(Collections::emptySet)) {
+        for (ProjectHiearchy dep : hiearchy.getDependencies()) {
             if (dep.isSelected()) {
                 nextLevelDependencyIds.add(create(dep, allDependencyIds));
             }

--- a/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
@@ -62,7 +62,7 @@ public class BuildConfigurationGeneratorImpl implements BuildConfigurationGenera
         ge.getToplevelProject().setName(ProjectHiearchyCreator.getName(deps.getGav()));
 
         ge.getToplevelBc().setDependencies(
-                Optional.of(nextLevel.processDependencies(ge, deps.getDependencies())));
+                nextLevel.processDependencies(ge, deps.getDependencies()));
 
         // the top level BC has its dependencies analyzed
         ge.getToplevelBc().setAnalysisStatus(DependencyAnalysisStatus.ANALYZED);
@@ -113,7 +113,7 @@ public class BuildConfigurationGeneratorImpl implements BuildConfigurationGenera
                     "BuildConfiguration name doesn't match expected format. BuildConfiguration name: "
                             + project.getName());
 
-        for (ProjectHiearchy dep : hiearchy.getDependencies().orElse(Collections.emptySet())) {
+        for (ProjectHiearchy dep : hiearchy.getDependencies()) {
             validate(dep);
         }
     }

--- a/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/impl/BuildConfigurationGeneratorImpl.java
@@ -6,6 +6,7 @@ import org.jboss.da.bc.api.BuildConfigurationGenerator;
 import org.jboss.da.bc.backend.api.Finalizer;
 import org.jboss.da.bc.backend.api.POMInfo;
 import org.jboss.da.bc.backend.api.POMInfoGenerator;
+import org.jboss.da.bc.model.DependencyAnalysisStatus;
 import org.jboss.da.bc.model.GeneratorEntity;
 import org.jboss.da.bc.model.ProjectDetail;
 import org.jboss.da.bc.model.ProjectHiearchy;
@@ -62,6 +63,9 @@ public class BuildConfigurationGeneratorImpl implements BuildConfigurationGenera
 
         ge.getToplevelBc().setDependencies(
                 Optional.of(nextLevel.processDependencies(ge, deps.getDependencies())));
+
+        // the top level BC has its dependencies analyzed
+        ge.getToplevelBc().setAnalysisStatus(DependencyAnalysisStatus.ANALYZED);
 
         return ge;
     }

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/DependencyAnalysisStatus.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/DependencyAnalysisStatus.java
@@ -1,0 +1,5 @@
+package org.jboss.da.bc.model;
+
+public enum DependencyAnalysisStatus {
+    FAILED, ANALYZED, NOT_ANALYSED
+}

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectHiearchy.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectHiearchy.java
@@ -17,6 +17,10 @@ public class ProjectHiearchy {
 
     @Getter
     @Setter
+    private DependencyAnalysisStatus analysisStatus = DependencyAnalysisStatus.NOT_ANALYSED;
+
+    @Getter
+    @Setter
     @JsonUnwrapped
     private ProjectDetail project;
 

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectHiearchy.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectHiearchy.java
@@ -29,14 +29,14 @@ public class ProjectHiearchy {
     private boolean selected;
 
     @Getter
-    private Optional<Set<ProjectHiearchy>> dependencies = Optional.of(Collections.emptySet());
+    private Set<ProjectHiearchy> dependencies = Collections.emptySet();
 
     public ProjectHiearchy(ProjectDetail project, boolean nextLevel) {
         this.project = project;
         this.selected = nextLevel;
     }
 
-    public void setDependencies(Optional<Set<ProjectHiearchy>> dependencies) {
+    public void setDependencies(Set<ProjectHiearchy> dependencies) {
         this.dependencies = dependencies;
     }
 

--- a/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
@@ -133,6 +133,7 @@ public class BuildConfigurationsProduct {
         bc.setBcId(p.getBcId());
         bc.setSelected(ph.isSelected());
         bc.setUseExistingBc(p.isUseExistingBc());
+        bc.setAnalysisStatus(ph.getAnalysisStatus());
 
         List<BuildConfiguration> dependencies = ph.getDependencies()
                 .map(deps -> deps.stream()
@@ -181,6 +182,7 @@ public class BuildConfigurationsProduct {
             ph.setDependencies(Optional.of(bc.getDependencies().stream()
                     .map(dep -> toProjectHiearchy(dep)).collect(Collectors.toSet())));
         }
+        ph.setAnalysisStatus(bc.getAnalysisStatus());
         return ph;
     }
 }

--- a/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
@@ -136,10 +136,9 @@ public class BuildConfigurationsProduct {
         bc.setAnalysisStatus(ph.getAnalysisStatus());
 
         List<BuildConfiguration> dependencies = ph.getDependencies()
-                .map(deps -> deps.stream()
-                        .map(x -> toBuildConfiguration(x))
-                        .collect(Collectors.toList()))
-                .orElse(null);
+                .stream()
+                .map(x -> toBuildConfiguration(x))
+                .collect(Collectors.toList());
         bc.setDependencies(dependencies);
 
         return bc;
@@ -176,11 +175,9 @@ public class BuildConfigurationsProduct {
 
         ProjectHiearchy ph = new ProjectHiearchy(pd, bc.isSelected());
 
-        if (bc.getDependencies() == null) {
-            ph.setDependencies(Optional.empty());
-        } else {
-            ph.setDependencies(Optional.of(bc.getDependencies().stream()
-                    .map(dep -> toProjectHiearchy(dep)).collect(Collectors.toSet())));
+        if (bc.getDependencies() != null) {
+            ph.setDependencies(bc.getDependencies().stream()
+                    .map(dep -> toProjectHiearchy(dep)).collect(Collectors.toSet()));
         }
         ph.setAnalysisStatus(bc.getAnalysisStatus());
         return ph;

--- a/bc-rest/src/main/java/org/jboss/da/bc/model/BuildConfiguration.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/model/BuildConfiguration.java
@@ -21,6 +21,10 @@ public class BuildConfiguration {
 
     @Getter
     @Setter
+    protected DependencyAnalysisStatus analysisStatus;
+
+    @Getter
+    @Setter
     protected String scmUrl;
 
     @Getter

--- a/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
@@ -2,6 +2,7 @@ package org.jboss.da.reports.api;
 
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.PomAnalysisException;
 
@@ -35,6 +36,7 @@ public interface ReportsGenerator {
      * @return Created report or empty Optional if the requested GAV was not found in the repository
      * @throws CommunicationException when there is a problem with communication with remote services
      */
-    public Optional<ArtifactReport> getReport(GAV gav) throws CommunicationException;
+    public ArtifactReport getReport(GAV gav) throws CommunicationException,
+            FindGAVDependencyException;
 
 }

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
@@ -3,6 +3,7 @@ package org.jboss.da.reports.backend.api;
 import java.util.Optional;
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.PomAnalysisException;
@@ -17,7 +18,8 @@ public interface DependencyTreeGenerator {
     public GAVDependencyTree getDependencyTree(SCMLocator scml) throws ScmException,
             PomAnalysisException;
 
-    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException;
+    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException,
+            FindGAVDependencyException;
 
     public GAVDependencyTree getDependencyTree(String url, String revision, GAV gav)
             throws ScmException, PomAnalysisException;
@@ -26,7 +28,7 @@ public interface DependencyTreeGenerator {
             PomAnalysisException;
 
     public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav)
-            throws CommunicationException;
+            throws CommunicationException, FindGAVDependencyException;
 
     public GAVToplevelDependencies getToplevelDependencies(String url, String revision, GAV gav)
             throws ScmException, PomAnalysisException;

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/api/DependencyTreeGenerator.java
@@ -1,6 +1,5 @@
 package org.jboss.da.reports.backend.api;
 
-import java.util.Optional;
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.communication.CommunicationException;
 import org.jboss.da.communication.aprox.FindGAVDependencyException;
@@ -18,7 +17,7 @@ public interface DependencyTreeGenerator {
     public GAVDependencyTree getDependencyTree(SCMLocator scml) throws ScmException,
             PomAnalysisException;
 
-    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException,
+    public GAVDependencyTree getDependencyTree(GAV gav) throws CommunicationException,
             FindGAVDependencyException;
 
     public GAVDependencyTree getDependencyTree(String url, String revision, GAV gav)
@@ -27,8 +26,8 @@ public interface DependencyTreeGenerator {
     public GAVToplevelDependencies getToplevelDependencies(SCMLocator scml) throws ScmException,
             PomAnalysisException;
 
-    public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav)
-            throws CommunicationException, FindGAVDependencyException;
+    public GAVToplevelDependencies getToplevelDependencies(GAV gav) throws CommunicationException,
+            FindGAVDependencyException;
 
     public GAVToplevelDependencies getToplevelDependencies(String url, String revision, GAV gav)
             throws ScmException, PomAnalysisException;

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -1,6 +1,5 @@
 package org.jboss.da.reports.backend.impl;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jboss.da.communication.CommunicationException;
@@ -40,9 +39,9 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     }
 
     @Override
-    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException,
+    public GAVDependencyTree getDependencyTree(GAV gav) throws CommunicationException,
             FindGAVDependencyException {
-        return Optional.of(aproxConnector.getDependencyTreeOfGAV(gav));
+        return aproxConnector.getDependencyTreeOfGAV(gav);
     }
 
     @Override
@@ -59,8 +58,9 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     }
 
     @Override
-    public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav) throws CommunicationException, FindGAVDependencyException {
-        return getDependencyTree(gav).map(tree -> treeToToplevel(tree));
+    public GAVToplevelDependencies getToplevelDependencies(GAV gav) throws CommunicationException,
+            FindGAVDependencyException {
+        return treeToToplevel(getDependencyTree(gav));
     }
 
     @Override

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -40,13 +40,9 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     }
 
     @Override
-    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException {
-        try {
-            return Optional.of(aproxConnector.getDependencyTreeOfGAV(gav));
-        } catch (FindGAVDependencyException e) {
-            // TODO: better handle this later in DA-170
-            return Optional.empty();
-        }
+    public Optional<GAVDependencyTree> getDependencyTree(GAV gav) throws CommunicationException,
+            FindGAVDependencyException {
+        return Optional.of(aproxConnector.getDependencyTreeOfGAV(gav));
     }
 
     @Override
@@ -63,7 +59,7 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     }
 
     @Override
-    public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav) throws CommunicationException {
+    public Optional<GAVToplevelDependencies> getToplevelDependencies(GAV gav) throws CommunicationException, FindGAVDependencyException {
         return getDependencyTree(gav).map(tree -> treeToToplevel(tree));
     }
 

--- a/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
@@ -77,16 +77,14 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
         if (gav == null)
             throw new IllegalArgumentException("GAV can't be null");
 
-        Optional<GAVDependencyTree> dt = dependencyTreeGenerator.getDependencyTree(gav);
+        GAVDependencyTree dt = dependencyTreeGenerator.getDependencyTree(gav);
 
         Set<GAVDependencyTree> nodesVisited = new HashSet<>();
         VersionLookupResult result = versionFinderImpl.lookupBuiltVersions(gav);
         ArtifactReport report = toArtifactReport(gav, result);
 
-        if (dt.isPresent()) {
-            nodesVisited.add(dt.get());
-            addDependencyReports(report, dt.get().getDependencies(), nodesVisited);
-        }
+        nodesVisited.add(dt);
+        addDependencyReports(report, dt.getDependencies(), nodesVisited);
 
         return report;
     }

--- a/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
@@ -1,6 +1,7 @@
 package org.jboss.da.reports.impl;
 
 import org.apache.maven.scm.ScmException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.CommunicationException;
 import org.jboss.da.communication.model.GAV;
@@ -71,23 +72,23 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
     }
 
     @Override
-    public Optional<ArtifactReport> getReport(GAV gav) throws CommunicationException {
+    public ArtifactReport getReport(GAV gav) throws CommunicationException,
+            FindGAVDependencyException {
         if (gav == null)
             throw new IllegalArgumentException("GAV can't be null");
 
         Optional<GAVDependencyTree> dt = dependencyTreeGenerator.getDependencyTree(gav);
 
-        if (!dt.isPresent())
-            return Optional.empty();
-
         Set<GAVDependencyTree> nodesVisited = new HashSet<>();
         VersionLookupResult result = versionFinderImpl.lookupBuiltVersions(gav);
         ArtifactReport report = toArtifactReport(gav, result);
-        nodesVisited.add(dt.get());
 
-        addDependencyReports(report, dt.get().getDependencies(), nodesVisited);
+        if (dt.isPresent()) {
+            nodesVisited.add(dt.get());
+            addDependencyReports(report, dt.get().getDependencies(), nodesVisited);
+        }
 
-        return Optional.of(report);
+        return report;
     }
 
     private ArtifactReport toArtifactReport(GAV gav, VersionLookupResult result) {

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -127,17 +127,15 @@ public class ReportsGeneratorImplTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNullGAV() throws CommunicationException {
+    public void testNullGAV() throws CommunicationException, FindGAVDependencyException {
         generator.getReport(null);
     }
 
-    @Test
+    @Test(expected = FindGAVDependencyException.class)
     public void testNonExistingGAV() throws CommunicationException, FindGAVDependencyException {
         when(aproxClient.getDependencyTreeOfGAV(daGAV)).thenThrow(FindGAVDependencyException.class);
 
-        Optional<ArtifactReport> report = generator.getReport(daGAV);
-
-        assertFalse(report.isPresent());
+        generator.getReport(daGAV);
     }
 
     @Test
@@ -145,7 +143,7 @@ public class ReportsGeneratorImplTest {
             FindGAVDependencyException {
         prepare(false, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
@@ -161,7 +159,7 @@ public class ReportsGeneratorImplTest {
             FindGAVDependencyException {
         prepare(true, false, daCoreVersionsNoBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
@@ -176,7 +174,7 @@ public class ReportsGeneratorImplTest {
             FindGAVDependencyException {
         prepare(false, true, daCoreVersionsBest, bestMatchVersion, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());
@@ -191,7 +189,7 @@ public class ReportsGeneratorImplTest {
             throws CommunicationException, FindGAVDependencyException {
         prepare(false, false, daCoreVersionsBest, null, daCoreNoDT);
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertFalse(report.getBestMatchVersion().isPresent());
         assertFalse(report.getAvailableVersions().stream().anyMatch(version -> version == null));
@@ -201,7 +199,7 @@ public class ReportsGeneratorImplTest {
     public void testGetMultipleReport() throws CommunicationException, FindGAVDependencyException {
         prepareMulti();
 
-        ArtifactReport report = generator.getReport(daCoreGAV).get();
+        ArtifactReport report = generator.getReport(daCoreGAV);
 
         assertTrue(report.getAvailableVersions().containsAll(daCoreVersionsNoBest));
         assertEquals(daCoreGAV, report.getGav());

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -2,6 +2,7 @@ package org.jboss.da.rest.reports;
 
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.communication.CommunicationException;
+import org.jboss.da.communication.aprox.FindGAVDependencyException;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.PomAnalysisException;
 import org.jboss.da.listings.api.service.BlackArtifactService;
@@ -90,9 +91,7 @@ public class Reports {
     @Path("/gav")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(
-            value = "Get dependency report for a GAV ",
-            response = ArtifactReport.class)
+    @ApiOperation(value = "Get dependency report for a GAV ", response = ArtifactReport.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Report was successfully generated"),
             @ApiResponse(code = 404, message = "Requested GAV was not found in repository"),
@@ -100,14 +99,15 @@ public class Reports {
     public Response gavGenerator(@ApiParam(
             value = "JSON Object with keys 'groupId', 'artifactId', and 'version'") GAV gavRequest) {
         try {
-            Optional<ArtifactReport> artifactReport = reportsGenerator.getReport(gavRequest);
-            return artifactReport
-                    .map(x -> Response.ok().entity(toReport(x)).build())
-                    .orElseGet(() -> Response.status(Status.NOT_FOUND)
-                            .entity(new ErrorMessage("Requested GAV was not found in repository")).build());
+            ArtifactReport artifactReport = reportsGenerator.getReport(gavRequest);
+            return Response.ok().entity(toReport(artifactReport)).build();
         } catch (CommunicationException ex) {
             log.error("Communication with remote repository failed", ex);
             return Response.status(502).entity(ex).build();
+        } catch (FindGAVDependencyException ex) {
+            log.error("Could not find gav in AProx", ex);
+            return Response.status(Status.NOT_FOUND)
+                    .entity(new ErrorMessage("Requested GA was not found")).build();
         }
     }
 


### PR DESCRIPTION
When using the bcg endpoint to analyze dependencies, it would be nice to
also get a status of how the dependencies went. Did the analysis
succeeded, failed, or has not been done yet?

In the longer term, this status field could be used in PNC UI to throw
relevant notifications to the user.

This commit builds on DA-171 which adds a way to know if Aprox could not
analyse a particular GAV. DA-171 is required to know whether the
analysis of the GAV failed, or the GAV had no dependencies. Previously
the two cases mentioned above could not be distinguished.

We add the status field by first creating an enum
(`DependencyAnalysisStatus`), and adding the status field to the backend
DAO `ProjectHierarchy` and the frontend DAO `BuildConfiguration`.

Most of the other changes occur in `ProjectHiearchyCreator` where we use
the new status field to know if we need to analyze a dependency or not.

The status field is populated in `getDependencies` method in
`ProjectHiearchyCreator`.

The rest of the changes is on the methods converting a `ProjectHiearchy`
to a `BuildConfiguration`, and vice-versa.