### PR TITLE
[DA-152] Add option to generate JUnit XML file

### DIFF
--- a/cli/da-cli-admin.sh
+++ b/cli/da-cli-admin.sh
@@ -33,6 +33,9 @@ printUsage() {
     echo "$0 pom-bw [--transitive] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status."
     echo ""
+    echo "$0 pom-bw-junit-xml [--transitive] [path]";
+    echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status, and generate a JUnit XML file"
+    echo ""
     echo "$0 pom-report [--transitive] [--raw] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status."
     echo "    Output: "
@@ -56,6 +59,7 @@ case $action in
     check) check $2 $3;;
     list) list $2;;
     pom-bw) pom_bw $2 $3;;
+    pom-bw-junit-xml) pom_bw_junit_xml $2 $3;;
     pom-report) pom_report $2 $3;;
     lookup) lookup $2;;
     report) report $2 $3;;

--- a/cli/da-cli.sh
+++ b/cli/da-cli.sh
@@ -27,6 +27,9 @@ printUsage() {
     echo "$0 pom-bw [--transitive] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status."
     echo ""
+    echo "$0 pom-bw-junit-xml [--transitive] [path]";
+    echo "    Check all dependencies from pom in working directory (using dependency:list) and print their Black/White list status, and generate a JUnit XML file"
+    echo ""
     echo "$0 pom-report [--transitive] [--raw] [path]";
     echo "    Check all dependencies from pom in working directory (using dependency:list) and print their report status."
     echo "    Output: "
@@ -48,6 +51,7 @@ case $action in
     check) check $2 $3;;
     list) list $2;;
     pom-bw) pom_bw $2 $3;;
+    pom-bw-junit-xml) pom_bw_junit_xml $2 $3;;
     pom-report) pom_report $2 $3;;
     lookup) lookup $2;;
     report) report $2 $3;;

--- a/cli/listings.sh
+++ b/cli/listings.sh
@@ -197,6 +197,44 @@ parse_pom_bw_report_options() {
     fi
 }
 
+pom_bw_junit_xml() {
+    parse_pom_bw_report_options "$@"
+
+    mvn_opts=""
+    if [ ${pom_transitive_flag} = true ]; then
+        mvn_opts="$mvn_opts"
+    else
+        mvn_opts="$mvn_opts -DexcludeTransitive=true"
+    fi
+
+    local tmpfile=`gettmpfile`
+    pushd "${pom_path}" > /dev/null
+    mvn -q dependency:list -DoutputFile=$tmpfile -DappendOutput=true $mvn_opts
+
+    if [ $? -ne 0 ]; then
+        rm $tmpfile
+        echo ""
+        echo ""
+        echo "================================================================="
+        echo "'mvn dependency:list' command failed."
+        echo "Consider running 'mvn clean install' before running the pom-bw command again to fix the issue"
+        echo "================================================================="
+        exit
+    fi
+
+    popd > /dev/null
+
+    local pkg_list_file=`gettmpfile`
+    sort -u $tmpfile | grep "^ *.*:.*:.*:.*"| sed "s/^ *//" | awk 'BEGIN {IFS=":"; FS=":"; OFS=":"} {print $1,$2,$4}' | while read line; do
+        echo "${line}" >> ${pkg_list_file}
+    done
+
+    python ${basedir}/testsuite.py ${pkg_list_file}
+
+    rm ${tmpfile}
+    rm ${pkg_list_file}
+}
+
 pom_bw() {
 
     parse_pom_bw_report_options "$@"

--- a/cli/testsuite.py
+++ b/cli/testsuite.py
@@ -1,0 +1,116 @@
+from xml.dom import minidom
+import sys
+import requests
+
+DA_MAIN_SERVER="ncl-test-vm-01.host.prod.eng.bos.redhat.com:8180/da/rest/v-0.3"
+class Testsuite:
+    """
+    Class used to create and generate JUnit XML definitions
+    """
+
+    def __init__(self):
+        self.doc = minidom.Document()
+        self.root = self.doc.createElement('testsuite')
+        self.doc.appendChild(self.root)
+
+
+    def add_passing_testcase(self, classname, name):
+        """
+        Add a passing testcase to our JUnit XML
+
+        classname: :string:
+        name: :string:
+        """
+        leaf = self.doc.createElement('testcase')
+        leaf.setAttribute('classname', classname)
+        leaf.setAttribute('name', name)
+        self.root.appendChild(leaf)
+
+
+    def add_failing_testcase(self, classname, name, error_message):
+        """
+        Add a failing testcase to our JUnit XML
+
+        classname: :string:
+        name: :string:
+        error_message: :string:
+        """
+        leaf = self.doc.createElement('testcase')
+        leaf.setAttribute('classname', classname)
+        leaf.setAttribute('name', name)
+        self.root.appendChild(leaf)
+
+        leaf_error = self.doc.createElement('error')
+        leaf_error.setAttribute('message', error_message)
+        leaf.appendChild(leaf_error)
+
+
+    def write_doc(self, xml_file):
+        """
+        Write the JUnit xml to `xml_file`
+
+        xml_file: :string:
+        """
+        xml_str = self.doc.toprettyxml(indent="  ")
+        with open(xml_file, "w") as f:
+            f.write(xml_str)
+
+
+def is_in_list(type_of_list, gav):
+    """
+    type_of_list can be: 'whitelist' or 'blacklist'
+    """
+    gav_broken = gav.split(':')
+    group_id = gav_broken[0]
+    artifact_id = gav_broken[1]
+    version = gav_broken[2].strip()
+
+    request = "listings/" + type_of_list + \
+              "/gav?groupid=" + group_id + \
+              "&artifactid=" + artifact_id + \
+              "&version=" + version
+
+    full_request = "http://" + DA_MAIN_SERVER + "/" + request
+    r = requests.get(full_request)
+
+    return r.status_code == 200
+
+
+def is_blacklisted(gav):
+    return is_in_list('blacklist', gav)
+
+
+def is_whitelisted(gav):
+    return is_in_list('whitelist', gav)
+
+
+def main(filename, xml_file):
+
+
+    packages = set()
+    testsuite = Testsuite()
+    with open(filename, 'r') as f:
+
+        for item in f:
+            packages.add(item.strip())
+
+    for gav in packages:
+
+        if is_whitelisted(gav):
+            testsuite.add_passing_testcase('whitelist', gav)
+        elif is_blacklisted(gav):
+            testsuite.add_failing_testcase('blacklist', gav, gav + ' is in the blacklist')
+        else:
+            # if not in list, consider it as passed
+            testsuite.add_passing_testcase('no-list', gav)
+
+    testsuite.write_doc(xml_file)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) <= 1:
+        print("Not enough paramaters")
+        print("<script> <file of GAVs>")
+        sys.exit(1)
+
+    main(sys.argv[1], 'junit.xml')


### PR DESCRIPTION
This generation will only happen for black and white list files. The file created will be named 'junit.xml'

To run:
```
<path>/da-cli.sh pom-bw-junit-xml <path of maven repo>
```
Blacklisted GAV will be marked as a failed test. Not listed GAV are assumed to be successful tests.
Whitelisted GAVs are considered successful tests.

Maybe this generation will be enabled for other reports, as required.

Note: This gif, and webpage, was generated using the 'junit-viewer' npm library, by feeding on the junit.xml file generated. This particular testsuite was run on the pnc project.

![junit_xml](https://cloud.githubusercontent.com/assets/630746/11256943/dd9669ae-8e1c-11e5-8e03-0301890c794d.gif)
