### PR TITLE
[DA-167][DA-169] Behaviour on existing PNC entities

### DIFF
--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/api/BCSetGenerator.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/api/BCSetGenerator.java
@@ -9,18 +9,36 @@ import java.util.List;
 public interface BCSetGenerator {
 
     /**
-     * Finds if BuildConfigurationSet with specified parameters already exists if not creates it
+     * Create a new BuildConfigurationSet.
+     * If the BuildConfigurationSet already exists, then throw a PNCRequestException.
+     *
+     * From DA-169, we have to report an error if the BuildConfigurationSet already
+     * exists.
      * 
      * @param name
      * @param productVersionId
      * @param bcIds
      * @return BuildConfigurationSet
      * @throws CommunicationException Thrown if communication with PNC failed
-     * @throws PNCRequestException Thrown if PNC returns an error
+     * @throws PNCRequestException Thrown if PNC returns an error, or if the
+     *         BuildConfigurationSet already exists
      */
     BuildConfigurationSet createBCSet(String name, Integer productVersionId, List<Integer> bcIds)
             throws CommunicationException, PNCRequestException;
 
+    /**
+     * Find the Product on PNC and create the product version for that product.
+     * If the Product already exists, re-use it.
+     *
+     * From DA-167, if the ProductVersion already exists, we will re-use it
+     * and create a new BuildConfigurationSet
+     *
+     * @param name name of product to find
+     * @param productVersion version of product to create
+     * @return The id of the product version created, or found
+     * @throws CommunicationException Thrown if communication with PNC failed
+     * @throws PNCRequestException Thrown if PNC returns an error
+     */
     Integer createProduct(String name, String productVersion) throws CommunicationException,
             PNCRequestException;
 }

--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
@@ -1,7 +1,6 @@
 package org.jboss.da.bc.backend.impl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -22,8 +21,6 @@ import org.jboss.da.communication.pnc.model.BuildConfiguration;
 import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
 import org.jboss.da.scm.api.SCMType;
 import org.slf4j.Logger;
-
-import java.util.List;
 
 /**
  *

--- a/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
@@ -8,6 +8,7 @@ import org.jboss.da.communication.pnc.model.Product;
 import org.jboss.da.communication.pnc.model.ProductVersion;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  *
@@ -62,10 +63,48 @@ public interface PNCConnector {
      * 
      * @param productVersionId
      * @param buildConfigurationIds
-     * @return BuildConfigurationSet or null if it is not found
+     * @return Optional.empty() if buildConfigurationSet not found, else the BuildConfigurationSet
+     * @throws CommunicationException Thrown if the communication with PNC failed
+     * @throws PNCRequestException Thrown if PNC returns an error
      */
-    BuildConfigurationSet findBuildConfigurationSet(int productVersionId,
-            List<Integer> buildConfigurationIds);
+    Optional<BuildConfigurationSet> findBuildConfigurationSet(int productVersionId,
+            List<Integer> buildConfigurationIds) throws CommunicationException, PNCRequestException;
+
+    /**
+     * Find ProductVersion assigned to a particular product and having a specific
+     * version. Since each product has unique product versions, we can only find
+     * one such ProductVersion
+     * @param product the product entity
+     * @param version the version to find
+     * @return Optional.empty() if productVersion not found, else the productVersion
+     * @throws CommunicationException Thrown if the communication with PNC failed
+     * @throws PNCRequestException Thrown if PNC returns an error
+     */
+    Optional<ProductVersion> findProductVersion(Product product, String version)
+            throws CommunicationException, PNCRequestException;
+
+    /**
+     * Find ProductVersion assigned to a particular product and having a specific
+     * version. Since each product has unique product versions, we can only find
+     * one such ProductVersion
+     * @param productId the product id
+     * @param version version to find
+     * @return Optional.empty() if productVersion not found, else the productVersion
+     * @throws CommunicationException Thrown if the communication with PNC failed
+     * @throws PNCRequestException Thrown if PNC returns an error
+     */
+    Optional<ProductVersion> findProductVersion(int productId, String version)
+            throws CommunicationException, PNCRequestException;
+
+    /**
+     * Find product having a particular name. Since each product has a unique
+     * name, we can only find one such product with that name
+     *
+     * @param name name of product
+     * @return Optional.empty() if product not found, else the Product
+     * @throws Exception
+     */
+    Optional<Product> findProduct(String name) throws CommunicationException, PNCRequestException;
 
     Product createProduct(Product p) throws CommunicationException, PNCRequestException;
 


### PR DESCRIPTION
DA-167: Check if the product version already exists. If it does not,
        create a new one. If it does, re-use the existing one.

DA-169: Check if the BuildConfigurationSet we are trying to use already
        exists. If yes, then throw an error since we assume that the
        BuildConfigurationSet we are going to use hasn't been created
        yet.

The error thrown is `PNCRequestException`.

Note: I didn't write any tests since it's pretty hard to write tests that won't easily break as the BuildConfigurations/BuildConfigurationSet/Product/ProductVersion of the PNC server we'll test with change.