### PR TITLE
[DA-204] advanced scm report

### DIFF
--- a/reports-backend/src/main/java/org/jboss/da/reports/api/AdvancedArtifactReport.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/AdvancedArtifactReport.java
@@ -1,0 +1,117 @@
+package org.jboss.da.reports.api;
+
+import org.jboss.da.common.version.VersionParser;
+import org.jboss.da.communication.model.GAV;
+import org.jboss.da.listings.api.service.WhiteArtifactService;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+
+public class AdvancedArtifactReport {
+
+    private WhiteArtifactService whiteArtifactService;
+
+    @Getter
+    private ArtifactReport artifactReport;
+
+    @Getter
+    private Set<GAV> blacklistArtifacts = new HashSet<>();
+
+    @Getter
+    private Set<GAV> whitelistArtifacts = new HashSet<>();
+
+    @Getter
+    private Set<GAV> communityGavsWithBestMatchVersions = new HashSet<>();
+
+    @Getter
+    private Set<GAV> communityGavsWithBuiltVersions = new HashSet<>();
+
+    @Getter
+    private Set<GAV> communityGavs = new HashSet<>();
+
+    public AdvancedArtifactReport(ArtifactReport artifactReport,
+            WhiteArtifactService whiteArtifactService) {
+        this.artifactReport = artifactReport;
+        this.whiteArtifactService = whiteArtifactService;
+        advancedReportGeneration();
+    }
+
+    public void advancedReportGeneration() {
+        Set<GAV> modulesAnalyzed = new HashSet<>();
+        populateAdvancedFields(artifactReport, modulesAnalyzed);
+    }
+
+    /**
+     * The logic on how the advanced fields are populated is determined from
+     * DA-204
+     *
+     * @param report          report to analyze
+     * @param modulesAnalyzed set of modules already analyzed
+     */
+    private void populateAdvancedFields(ArtifactReport report, Set<GAV> modulesAnalyzed) {
+
+        for (ArtifactReport dep : report.getDependencies()) {
+            if (modulesAnalyzed.contains(dep.getGav())) {
+                // if module already analyzed, skip
+                continue;
+            } else if (isDependencyAModule(dep)) {
+                // if dependency is a module, but not yet analyzed
+                modulesAnalyzed.add(dep.getGav());
+                populateAdvancedFields(dep, modulesAnalyzed);
+            } else {
+                // only generate populate advanced report with community GAVs
+                if (VersionParser.isRedhatVersion(dep.getVersion())) continue;
+
+                // we have a top-level module dependency
+                if (dep.isWhitelisted()) whitelistArtifacts.add(dep.getGav());
+                if (dep.isBlacklisted()) blacklistArtifacts.add(dep.getGav());
+
+                if (dep.getBestMatchVersion().isPresent()) {
+                    communityGavsWithBestMatchVersions.add(dep.getGav());
+                    // also add bestMatchVersion GAV to set
+                    communityGavsWithBestMatchVersions.add(new GAV(dep.getGroupId(),
+                            dep.getArtifactId(), dep.getBestMatchVersion().get()));
+                } else if (!dep.getAvailableVersions().isEmpty()) {
+                    communityGavsWithBuiltVersions.add(dep.getGav());
+
+                    // also add available versions to set
+                    dep.getAvailableVersions().stream()
+                            .forEach(v -> communityGavsWithBuiltVersions
+                                    .add(new GAV(dep.getGroupId(), dep.getArtifactId(), v)));
+
+                    // add any whitelisted GAVs, if any
+                    addWhitelistedGAVToCommunityGavsWithBuiltVersions(dep.getGroupId(), dep.getArtifactId());
+                } else if (hasWhitelistedGA(dep.getGroupId(), dep.getArtifactId())) {
+                    // no bestmatch version, no built versions, but we have GAVs whitelisted
+                    addWhitelistedGAVToCommunityGavsWithBuiltVersions(dep.getGroupId(), dep.getArtifactId());
+                } else {
+                    communityGavs.add(dep.getGav());
+                }
+            }
+        }
+    }
+
+    private boolean isDependencyAModule(ArtifactReport dependency) {
+        return dependency.getGroupId().equals(artifactReport.getGroupId())
+                && dependency.getVersion().equals(artifactReport.getVersion());
+    }
+
+    private boolean hasWhitelistedGA(String groupId, String artifactId) {
+        if (whiteArtifactService.getAll() == null) {
+            return false;
+        }
+        return whiteArtifactService.getAll().stream()
+                .anyMatch(white -> white.getArtifactId().equals(artifactId) && white.getGroupId().equals(groupId));
+    }
+
+    private void addWhitelistedGAVToCommunityGavsWithBuiltVersions(String groupId, String artifactId) {
+        if (whiteArtifactService.getAll() == null) {
+            return;
+        }
+        whiteArtifactService.getAll().stream()
+                .filter(white -> white.getArtifactId().equals(artifactId) && white.getGroupId().equals(groupId))
+                .forEach(white -> communityGavsWithBuiltVersions.add(new GAV(groupId, artifactId, white.getVersion())));
+    }
+}

--- a/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
@@ -18,12 +18,27 @@ public interface ReportsGenerator {
 
     /**
      * Create a report about artifacts given an scm-url
-     * The report will only list the top-level dependencies used in the project
      * @param scml
      * @return Created report
      */
     public Optional<ArtifactReport> getReportFromSCM(SCMLocator scml) throws ScmException,
             PomAnalysisException, CommunicationException;
+
+    /**
+     * Create an advanced report about artifacts given an scm-url
+     * The advanced report will also contain lists of the top-level module dependencies
+     * which are:
+     * - blacklisted
+     * - whitelisted,
+     * - community gavs with a best match version
+     * - community gavs with built versions
+     * - community gavs
+     *
+     * @param scml
+     * @return Created report
+     */
+    public Optional<AdvancedArtifactReport> getAdvancedReportFromSCM(SCMLocator scml)
+            throws ScmException, PomAnalysisException, CommunicationException;
 
     public Optional<ArtifactReport> getReport(GAV gav, List<Product> products);
 

--- a/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
@@ -8,6 +8,7 @@ import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.PomAnalysisException;
 import org.jboss.da.listings.api.service.BlackArtifactService;
 import org.jboss.da.listings.api.service.WhiteArtifactService;
+import org.jboss.da.reports.api.AdvancedArtifactReport;
 import org.jboss.da.reports.api.ArtifactReport;
 import org.jboss.da.reports.api.Product;
 import org.jboss.da.reports.api.ReportsGenerator;
@@ -65,6 +66,14 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
         addDependencyReports(report, dt.getDependencies(), nodesVisited);
 
         return Optional.of(report);
+    }
+
+    @Override
+    public Optional<AdvancedArtifactReport> getAdvancedReportFromSCM(SCMLocator scml) throws ScmException,
+            PomAnalysisException, CommunicationException {
+        Optional<ArtifactReport> artifactReport = getReportFromSCM(scml);
+
+        return artifactReport.map(r -> new AdvancedArtifactReport(r, whiteArtifactService));
     }
 
     @Override

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -68,7 +68,7 @@ public class Reports {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get dependency report for a project specified in a repository URL",
-            response = ArtifactReport.class)
+            response = Report.class)
     public Response scmGenerator(@ApiParam(value = "scm information") SCMLocator scm) {
 
         try {
@@ -90,7 +90,7 @@ public class Reports {
     @Path("/gav")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get dependency report for a GAV ", response = ArtifactReport.class)
+    @ApiOperation(value = "Get dependency report for a GAV ", response = Report.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Report was successfully generated"),
             @ApiResponse(code = 404, message = "Requested GAV was not found in repository"),

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/model/AdvancedReport.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/model/AdvancedReport.java
@@ -1,0 +1,36 @@
+package org.jboss.da.rest.reports.model;
+
+import org.jboss.da.communication.model.GAV;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@RequiredArgsConstructor
+public class AdvancedReport {
+
+    @Getter
+    @NonNull
+    private Report report;
+
+    @Getter
+    @NonNull
+    private Set<GAV> blacklistArtifacts;
+
+    @Getter
+    @NonNull
+    private Set<GAV> whitelistArtifacts;
+
+    @Getter
+    @NonNull
+    private Set<GAV> communityGavsWithBestMatchVersions;
+
+    @Getter
+    @NonNull
+    private Set<GAV> communityGavsWithBuiltVersions;
+
+    @Getter
+    @NonNull
+    private Set<GAV> communityGavs;
+}


### PR DESCRIPTION
REST endpoint is `/reports/scm-advanced`

Behaviour
=========
The new report should be based on the current SCM report and provide
this information:

- whitelisted artifacts
- blacklisted artifacts

- community GAV's, which has bestMatchVersion match community GAV's,

- community GAV's, which has no bestMatchVersion, but have built
  versions of the same GA + if there are whitelisted versions of this
  GA, add them there too

- community GAV's

- The same tree of dependencies as in the SCM report

Note: community === non RH artifacts

Note2: we add both the dependency and the bestMatch version to the
       `communityGavsWithBestMatchVersions`, same for builtVersions +
       whitelisted.

It looks something like this:

```json
{
    "report": {the same report as /reports/scm},
    "blacklistedArtifacts": [],
    "whitelistedArtifacts": [],
    "communityGavsWithBestMatchVersions": [],
    "communityGavsWithBuiltVersions": [],
    "communityGavs": []
}
```