### PR TITLE
[DA-204] advanced scm report (based on comments)

### DIFF
--- a/reports-backend/src/main/java/org/jboss/da/reports/api/AdvancedArtifactReport.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/AdvancedArtifactReport.java
@@ -1,0 +1,49 @@
+package org.jboss.da.reports.api;
+
+import org.jboss.da.communication.model.GAV;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+
+public class AdvancedArtifactReport {
+
+    @Getter
+    @Setter
+    private ArtifactReport artifactReport;
+
+    @Getter
+    private Set<GAV> blacklistArtifacts = new HashSet<>();
+
+    @Getter
+    private Set<GAV> whitelistArtifacts = new HashSet<>();
+
+    @Getter
+    private Set<GAV> communityGavsWithBestMatchVersions = new HashSet<>();
+
+    @Getter
+    private Set<GAV> communityGavsWithBuiltVersions = new HashSet<>();
+
+    @Getter
+    private Set<GAV> communityGavs = new HashSet<>();
+
+    public void addBlacklistArtifact(GAV gav) {
+        blacklistArtifacts.add(gav);
+    }
+
+    public void addWhitelistArtifact(GAV gav) {
+        whitelistArtifacts.add(gav);
+    }
+
+    public void addCommunityGavWithBestMatchVersion(GAV gav) {
+        communityGavsWithBestMatchVersions.add(gav);
+    }
+
+    public void addCommunityGavWithBuiltVersion(GAV gav) {
+        communityGavsWithBuiltVersions.add(gav);
+    }
+
+    public void addCommunityGav(GAV gav) {
+        communityGavs.add(gav);
+    }
+}

--- a/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/ReportsGenerator.java
@@ -18,12 +18,27 @@ public interface ReportsGenerator {
 
     /**
      * Create a report about artifacts given an scm-url
-     * The report will only list the top-level dependencies used in the project
      * @param scml
      * @return Created report
      */
     public Optional<ArtifactReport> getReportFromSCM(SCMLocator scml) throws ScmException,
             PomAnalysisException, CommunicationException;
+
+    /**
+     * Create an advanced report about artifacts given an scm-url
+     * The advanced report will also contain lists of the top-level module dependencies
+     * which are:
+     * - blacklisted
+     * - whitelisted,
+     * - community gavs with a best match version
+     * - community gavs with built versions
+     * - community gavs
+     *
+     * @param scml
+     * @return Created report
+     */
+    public Optional<AdvancedArtifactReport> getAdvancedReportFromSCM(SCMLocator scml)
+            throws ScmException, PomAnalysisException, CommunicationException;
 
     public Optional<ArtifactReport> getReport(GAV gav, List<Product> products);
 

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -68,7 +68,7 @@ public class Reports {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get dependency report for a project specified in a repository URL",
-            response = ArtifactReport.class)
+            response = Report.class)
     public Response scmGenerator(@ApiParam(value = "scm information") SCMLocator scm) {
 
         try {
@@ -90,7 +90,7 @@ public class Reports {
     @Path("/gav")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get dependency report for a GAV ", response = ArtifactReport.class)
+    @ApiOperation(value = "Get dependency report for a GAV ", response = Report.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Report was successfully generated"),
             @ApiResponse(code = 404, message = "Requested GAV was not found in repository"),

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/model/AdvancedReport.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/model/AdvancedReport.java
@@ -1,0 +1,36 @@
+package org.jboss.da.rest.reports.model;
+
+import org.jboss.da.communication.model.GAV;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@RequiredArgsConstructor
+public class AdvancedReport {
+
+    @Getter
+    @NonNull
+    private Report report;
+
+    @Getter
+    @NonNull
+    private Set<GAV> blacklistArtifacts;
+
+    @Getter
+    @NonNull
+    private Set<GAV> whitelistArtifacts;
+
+    @Getter
+    @NonNull
+    private Set<GAV> communityGavsWithBestMatchVersions;
+
+    @Getter
+    @NonNull
+    private Set<GAV> communityGavsWithBuiltVersions;
+
+    @Getter
+    @NonNull
+    private Set<GAV> communityGavs;
+}


### PR DESCRIPTION
REST endpoint is `/reports/scm-advanced`

Behaviour
=========
The new report should be based on the current SCM report and provide
this information:

- whitelisted artifacts
- blacklisted artifacts

- community GAV's, which has bestMatchVersion match community GAV's,

- community GAV's, which has no bestMatchVersion, but have built
  versions of the same GA + if there are whitelisted versions of this
  GA, add them there too

- community GAV's

- The same tree of dependencies as in the SCM report

Note: community === non RH artifacts

Note2: we only add the dependency to the
       `communityGavsWithBestMatchVersions`, same for builtVersions +
       whitelisted.

It looks something like this:

```json
{
    "report": {the same report as /reports/scm},
    "blacklistedArtifacts": [],
    "whitelistedArtifacts": [],
    "communityGavsWithBestMatchVersions": [],
    "communityGavsWithBuiltVersions": [],
    "communityGavs": []
}
```

This is a PR based on the comments from: #215 