### PR TITLE
Rename some fields in the advanced scm report

### DIFF
--- a/reports-backend/src/main/java/org/jboss/da/reports/api/AdvancedArtifactReport.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/api/AdvancedArtifactReport.java
@@ -13,10 +13,10 @@ public class AdvancedArtifactReport {
     private ArtifactReport artifactReport;
 
     @Getter
-    private Set<GAV> blacklistArtifacts = new HashSet<>();
+    private Set<GAV> blacklistedArtifacts = new HashSet<>();
 
     @Getter
-    private Set<GAV> whitelistArtifacts = new HashSet<>();
+    private Set<GAV> whitelistedArtifacts = new HashSet<>();
 
     @Getter
     private Set<GAV> communityGavsWithBestMatchVersions = new HashSet<>();
@@ -27,12 +27,12 @@ public class AdvancedArtifactReport {
     @Getter
     private Set<GAV> communityGavs = new HashSet<>();
 
-    public void addBlacklistArtifact(GAV gav) {
-        blacklistArtifacts.add(gav);
+    public void addBlacklistedArtifact(GAV gav) {
+        blacklistedArtifacts.add(gav);
     }
 
-    public void addWhitelistArtifact(GAV gav) {
-        whitelistArtifacts.add(gav);
+    public void addWhitelistedArtifact(GAV gav) {
+        whitelistedArtifacts.add(gav);
     }
 
     public void addCommunityGavWithBestMatchVersion(GAV gav) {

--- a/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
@@ -169,9 +169,9 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
 
                 // we have a top-level module dependency
                 if (dep.isWhitelisted())
-                    advancedReport.addWhitelistArtifact(dep.getGav());
+                    advancedReport.addWhitelistedArtifact(dep.getGav());
                 if (dep.isBlacklisted())
-                    advancedReport.addBlacklistArtifact(dep.getGav());
+                    advancedReport.addBlacklistedArtifact(dep.getGav());
 
                 if (dep.getBestMatchVersion().isPresent()) {
                     advancedReport.addCommunityGavWithBestMatchVersion(dep.getGav());

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -185,8 +185,8 @@ public class Reports {
     private static AdvancedReport toAdvancedReport(AdvancedArtifactReport advancedArtifactReport) {
 
         Report report = toReport(advancedArtifactReport.getArtifactReport());
-        return new AdvancedReport(report, advancedArtifactReport.getBlacklistArtifacts(),
-                advancedArtifactReport.getWhitelistArtifacts(),
+        return new AdvancedReport(report, advancedArtifactReport.getBlacklistedArtifacts(),
+                advancedArtifactReport.getWhitelistedArtifacts(),
                 advancedArtifactReport.getCommunityGavsWithBestMatchVersions(),
                 advancedArtifactReport.getCommunityGavsWithBuiltVersions(),
                 advancedArtifactReport.getCommunityGavs());

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/model/AdvancedReport.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/model/AdvancedReport.java
@@ -16,11 +16,11 @@ public class AdvancedReport {
 
     @Getter
     @NonNull
-    private Set<GAV> blacklistArtifacts;
+    private Set<GAV> blacklistedArtifacts;
 
     @Getter
     @NonNull
-    private Set<GAV> whitelistArtifacts;
+    private Set<GAV> whitelistedArtifacts;
 
     @Getter
     @NonNull


### PR DESCRIPTION
Everywhere in the codebase we refer to artifacts as either being
'whitelisted' or 'blacklisted'. This commit makes the adavnced scm
report consistent with that convention by renaming:

- 'whitelistArtifact' to 'whitelistedArtifact'
- 'blacklistArtifact' to 'blacklistedArtifact'