### PR TITLE
[DA-228] Remove hardcoded application version, add property loading 

### DIFF
--- a/bc-rest/pom.xml
+++ b/bc-rest/pom.xml
@@ -52,6 +52,15 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <webResources>
+                        <resource>
+                            <directory>src/main/webapp</directory>
+                            <filtering>true</filtering>
+                            <includes>
+                                <include>**/*.html</include>
+                            </includes>
+                        </resource>
+                    </webResources>
                 </configuration>
             </plugin>
         </plugins>

--- a/bc-rest/src/main/webapp/WEB-INF/web.xml
+++ b/bc-rest/src/main/webapp/WEB-INF/web.xml
@@ -7,11 +7,11 @@
         <servlet-class>io.swagger.jaxrs.config.DefaultJaxrsConfig</servlet-class>
         <init-param>
             <param-name>api.version</param-name>
-            <param-value>0.3.0</param-value>
+            <param-value>${version.bc.rest}.0</param-value>
         </init-param>
         <init-param>
             <param-name>swagger.api.basepath</param-name>
-            <param-value>/da-bcg/rest/v-0.3</param-value>
+            <param-value>/da-bcg/rest/v-${version.bc.rest}</param-value>
         </init-param>
         <load-on-startup>2</load-on-startup>
     </servlet>

--- a/bc-rest/src/main/webapp/doc/index.html
+++ b/bc-rest/src/main/webapp/doc/index.html
@@ -33,7 +33,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "../rest/v-0.3/swagger.json";
+        url = "../rest/v-${version.bc.rest}/swagger.json";
       }
 
       // Pre load translate...

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -11,18 +11,18 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>  
+            <artifactId>resteasy-jaxrs</artifactId>
         </dependency>
-    
+
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson-provider</artifactId>
-        </dependency>   
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -47,4 +47,40 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>maven-replacer-plugin</artifactId>
+                <version>1.4.0</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <file>src/main/templates/org/jboss/da/common/Constants.java</file>
+                    <outputFile>src/main/java/org/jboss/da/common/Constants.java</outputFile>
+                    <replacements>
+                        <replacement>
+                            <token>@version.da@</token>
+                            <value>${version.da}</value>
+                        </replacement>
+                        <replacement>
+                            <token>@version.bc.rest@</token>
+                            <value>${version.bc.rest}</value>
+                        </replacement>
+                        <replacement>
+                            <token>@version.reports.rest@</token>
+                            <value>${version.reports.rest}</value>
+                        </replacement>
+                    </replacements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/src/main/java/org/jboss/da/common/Constants.java
+++ b/common/src/main/java/org/jboss/da/common/Constants.java
@@ -2,7 +2,10 @@ package org.jboss.da.common;
 
 public final class Constants {
 
+    public static final String DA_VERSION = "0.6.0-SNAPSHOT";
+
     public static final String REST_API_VERSION_BC = "0.3";
 
     public static final String REST_API_VERSION_REPORTS = "0.4";
+
 }

--- a/common/src/main/templates/org/jboss/da/common/Constants.java
+++ b/common/src/main/templates/org/jboss/da/common/Constants.java
@@ -1,0 +1,11 @@
+package org.jboss.da.common;
+
+public final class Constants {
+
+    public static final String DA_VERSION = "@version.da@";
+
+    public static final String REST_API_VERSION_BC = "@version.bc.rest@";
+
+    public static final String REST_API_VERSION_REPORTS = "@version.reports.rest@";
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.da>0.6.0-SNAPSHOT</version.da>
+        <version.reports.rest>0.4</version.reports.rest>
+        <version.bc.rest>0.3</version.bc.rest>
         <version.arquillian>1.1.8.Final</version.arquillian>
         <version.shrinkwrap.resolver>2.1.1</version.shrinkwrap.resolver>
         <version.aether>0.9.0.M2</version.aether>

--- a/reports-rest/pom.xml
+++ b/reports-rest/pom.xml
@@ -58,6 +58,15 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <webResources>
+                        <resource>
+                            <directory>src/main/webapp</directory>
+                            <filtering>true</filtering>
+                            <includes>
+                                <include>**/*.html</include>
+                            </includes>
+                        </resource>
+                    </webResources>
                 </configuration>
             </plugin>
         </plugins>

--- a/reports-rest/src/main/java/org/jboss/da/rest/Root.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/Root.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.MediaType;
 
 import static org.jboss.da.common.Constants.REST_API_VERSION_BC;
 import static org.jboss.da.common.Constants.REST_API_VERSION_REPORTS;
+import static org.jboss.da.common.Constants.DA_VERSION;
 
 /**
  *
@@ -22,7 +23,7 @@ public class Root {
         return "<h1>Dependency analysis service REST API</h1>"
                 + "\n"
                 + "<ul><li><strong>DA Version:</strong> "
-                + "0.5.1"
+                + DA_VERSION
                 + "</li>"
                 + "\n"
                 + "<li><strong>BC REST API Version:</strong> "

--- a/reports-rest/src/main/webapp/WEB-INF/web.xml
+++ b/reports-rest/src/main/webapp/WEB-INF/web.xml
@@ -7,11 +7,11 @@
         <servlet-class>io.swagger.jaxrs.config.DefaultJaxrsConfig</servlet-class>
         <init-param>
             <param-name>api.version</param-name>
-            <param-value>0.3.0</param-value>
+            <param-value>${version.reports.rest}.0</param-value>
         </init-param>
         <init-param>
             <param-name>swagger.api.basepath</param-name>
-            <param-value>/da/rest/v-0.4</param-value>
+            <param-value>/da/rest/v-${version.reports.rest}</param-value>
         </init-param>
         <load-on-startup>2</load-on-startup>
     </servlet>

--- a/reports-rest/src/main/webapp/doc/index.html
+++ b/reports-rest/src/main/webapp/doc/index.html
@@ -33,7 +33,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "../rest/v-0.4/swagger.json";
+        url = "../rest/v-${version.reports.rest}/swagger.json";
       }
 
       // Pre load translate...

--- a/testsuite/src/test/java/org/jboss/da/test/client/rest/RestApiIndexTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/client/rest/RestApiIndexTest.java
@@ -6,10 +6,10 @@ import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
 import org.junit.Test;
 
-import java.io.File;
-
-import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.apache.http.entity.ContentType.TEXT_HTML;
+import static org.jboss.da.common.Constants.DA_VERSION;
+import static org.jboss.da.common.Constants.REST_API_VERSION_BC;
+import static org.jboss.da.common.Constants.REST_API_VERSION_REPORTS;
 import static org.junit.Assert.assertEquals;
 
 public class RestApiIndexTest extends AbstractRestReportsTest {
@@ -23,9 +23,27 @@ public class RestApiIndexTest extends AbstractRestReportsTest {
 
         ClientResponse<String> response = request.get(String.class);
 
-        File expectedResponseFile = new ExpectedResponseFilenameBuilder(
-                restApiExpectedResponseFolder, path, contentType).getFile();
-        assertEquals(readFileToString(expectedResponseFile), response.getEntity(String.class));
+        assertEquals(getExpectedResponse(), response.getEntity(String.class));
+    }
+
+    private String getExpectedResponse() {
+        return "<h1>Dependency analysis service REST API</h1>"
+                + "\n"
+                + "<ul><li><strong>DA Version:</strong> "
+                + DA_VERSION
+                + "</li>"
+                + "\n"
+                + "<li><strong>BC REST API Version:</strong> "
+                + REST_API_VERSION_BC
+                + "</li>"
+                + "\n"
+                + "<li><strong>Reports REST API Version:</strong> "
+                + REST_API_VERSION_REPORTS
+                + "</li>"
+                + "\n"
+                + "<li><a href=\"../doc\">Swagger documentation</a></li>"
+                + "\n"
+                + "<li><strong>REST proposal documentation:</strong> <a href=\"https://docs.engineering.redhat.com/display/JP/REST+endpoints+proposal\">https://docs.engineering.redhat.com/display/JP/REST+endpoints+proposal</a></li></ul>";
     }
 
 }

--- a/testsuite/src/test/rest/v-1.0/expectedResponse/index.html
+++ b/testsuite/src/test/rest/v-1.0/expectedResponse/index.html
@@ -1,6 +1,0 @@
-<h1>Dependency analysis service REST API</h1>
-<ul><li><strong>DA Version:</strong> 0.5.1</li>
-<li><strong>BC REST API Version:</strong> 0.3</li>
-<li><strong>Reports REST API Version:</strong> 0.4</li>
-<li><a href="../doc">Swagger documentation</a></li>
-<li><strong>REST proposal documentation:</strong> <a href="https://docs.engineering.redhat.com/display/JP/REST+endpoints+proposal">https://docs.engineering.redhat.com/display/JP/REST+endpoints+proposal</a></li></ul>


### PR DESCRIPTION
I can't find out right settings of resource plugin to filter testsuite/src/test/rest/v-1.0/expectedResponse/index.html - i will look at it

I created https://docs.engineering.redhat.com/display/JP/Changing+of+REST+API+version so you know all places where you currently need to change version. We're using constants in app and these constants are used in annotations so I think the best state we can get is changing rest versions on 2 places in constants(for app) and in parent pom(for filter) 

If you know how to read property to annotation let me know.