### PR TITLE
[DA-192] Move creating of products to UI in Product Import

### DIFF
--- a/bc-backend/src/main/java/org/jboss/da/bc/api/ProductBuildConfigurationGenerator.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/api/ProductBuildConfigurationGenerator.java
@@ -15,9 +15,8 @@ import java.util.Optional;
  */
 public interface ProductBuildConfigurationGenerator {
 
-    ProductGeneratorEntity startBCGeneration(SCMLocator scm, String productName,
-            String productVersion) throws ScmException, PomAnalysisException,
-            CommunicationException;
+    ProductGeneratorEntity startBCGeneration(SCMLocator scm, int productId, String productVersion)
+            throws ScmException, PomAnalysisException, CommunicationException;
 
     ProductGeneratorEntity iterateBCGeneration(ProductGeneratorEntity projects)
             throws CommunicationException;

--- a/bc-backend/src/main/java/org/jboss/da/bc/api/ProjectBuildConfigurationGenerator.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/api/ProjectBuildConfigurationGenerator.java
@@ -14,8 +14,8 @@ import org.jboss.da.reports.api.SCMLocator;
  */
 public interface ProjectBuildConfigurationGenerator {
 
-    ProjectGeneratorEntity startBCGeneration(SCMLocator scm, String projectName)
-            throws ScmException, PomAnalysisException, CommunicationException;
+    ProjectGeneratorEntity startBCGeneration(SCMLocator scm, int projectId) throws ScmException,
+            PomAnalysisException, CommunicationException;
 
     ProjectGeneratorEntity iterateBCGeneration(ProjectGeneratorEntity projects)
             throws CommunicationException;

--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/api/BCSetGenerator.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/api/BCSetGenerator.java
@@ -28,17 +28,17 @@ public interface BCSetGenerator {
 
     /**
      * Find the Product on PNC and create the product version for that product.
-     * If the Product already exists, re-use it.
+     * The product must already exist.
      *
      * From DA-167, if the ProductVersion already exists, we will re-use it
      * and create a new BuildConfigurationSet
      *
-     * @param name name of product to find
+     * @param productId id of product to use
      * @param productVersion version of product to create
      * @return The id of the product version created, or found
      * @throws CommunicationException Thrown if communication with PNC failed
      * @throws PNCRequestException Thrown if PNC returns an error
      */
-    Integer createProduct(String name, String productVersion) throws CommunicationException,
-            PNCRequestException;
+    Integer createProductVersion(int productId, String productVersion)
+            throws CommunicationException, PNCRequestException;
 }

--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/api/Finalizer.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/api/Finalizer.java
@@ -10,9 +10,9 @@ import org.jboss.da.communication.pnc.api.PNCRequestException;
  */
 public interface Finalizer {
 
-    public Integer createBCs(String name, String productVersion, ProjectHiearchy toplevelBc,
+    public Integer createBCs(int id, String productVersion, ProjectHiearchy toplevelBc,
             String bcSetName) throws CommunicationException, PNCRequestException;
 
-    public Integer createBCs(String name, ProjectHiearchy toplevelBc)
-            throws CommunicationException, PNCRequestException;;
+    public Integer createBCs(int id, ProjectHiearchy toplevelBc) throws CommunicationException,
+            PNCRequestException;;
 }

--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/BCSetGeneratorImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/BCSetGeneratorImpl.java
@@ -41,27 +41,16 @@ public class BCSetGeneratorImpl implements BCSetGenerator {
     }
 
     @Override
-    public Integer createProduct(String name, String productVersion) throws CommunicationException,
-            PNCRequestException {
-        Optional<Product> p = pnc.findProduct(name);
+    public Integer createProductVersion(int productId, String productVersion)
+            throws CommunicationException, PNCRequestException {
 
-        Product product;
-
-        // create product if it does not exist
-        if (!p.isPresent()) {
-            product = pnc.createProduct(new Product(name));
-        } else {
-            product = p.get();
-        }
-
-        Optional<ProductVersion> potentialPV = pnc.findProductVersion(product, productVersion);
+        Optional<ProductVersion> potentialPV = pnc.findProductVersion(productId, productVersion);
 
         if (potentialPV.isPresent()) {
             return potentialPV.get().getId();
         }
         // if product version doesn't exist yet, create a new one
-        ProductVersion pv = pnc.createProductVersion(new ProductVersion(productVersion, product
-                .getId()));
+        ProductVersion pv = pnc.createProductVersion(new ProductVersion(productVersion, productId));
         return pv.getId();
 
     }

--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
@@ -47,12 +47,12 @@ public class FinalizerImpl implements Finalizer {
     private BcChecker bcFinder;
 
     @Override
-    public Integer createBCs(String name, String productVersion, ProjectHiearchy toplevelBc,
+    public Integer createBCs(int productId, String productVersion, ProjectHiearchy toplevelBc,
             String bcSetName) throws CommunicationException, PNCRequestException {
         Set<Integer> ids = new HashSet<>();
         try {
             create(toplevelBc, ids);
-            int productVersionId = bcSetGenerator.createProduct(name, productVersion);
+            int productVersionId = bcSetGenerator.createProductVersion(productId, productVersion);
             bcSetGenerator.createBCSet(bcSetName, productVersionId, new ArrayList<>(ids));
             return productVersionId;
         } catch (CommunicationException | PNCRequestException | RuntimeException ex) {
@@ -68,8 +68,8 @@ public class FinalizerImpl implements Finalizer {
     }
 
     @Override
-    public Integer createBCs(String name, ProjectHiearchy toplevelBc)
-            throws CommunicationException, PNCRequestException {
+    public Integer createBCs(int id, ProjectHiearchy toplevelBc) throws CommunicationException,
+            PNCRequestException {
         Set<Integer> ids = new HashSet<>();
         create(toplevelBc, ids);
         return create(toplevelBc, ids).iterator().next(); // get single integer

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/GeneratorEntity.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/GeneratorEntity.java
@@ -13,7 +13,7 @@ public abstract class GeneratorEntity {
 
     @Getter
     @Setter
-    String name;
+    int id;
 
     @Getter
     @Setter
@@ -27,12 +27,12 @@ public abstract class GeneratorEntity {
     @Setter
     ProjectHiearchy toplevelBc;
 
-    protected GeneratorEntity(SCMLocator scm, String name, GAV gav) {
+    protected GeneratorEntity(SCMLocator scm, int id, GAV gav) {
         ProjectDetail pd = new ProjectDetail(gav);
         pd.setScmUrl(scm.getScmUrl());
         pd.setScmRevision(scm.getRevision());
 
-        this.name = name;
+        this.id = id;
         this.pomPath = scm.getPomPath();
         this.toplevelBc = new ProjectHiearchy(pd, true);
     }
@@ -44,6 +44,6 @@ public abstract class GeneratorEntity {
     @FunctionalInterface
     public interface EntityConstructor<T extends GeneratorEntity> {
 
-        T construct(SCMLocator scm, String name, GAV gav);
+        T construct(SCMLocator scm, int id, GAV gav);
     }
 }

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/ProductGeneratorEntity.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/ProductGeneratorEntity.java
@@ -17,8 +17,8 @@ public class ProductGeneratorEntity extends GeneratorEntity {
     @Setter
     String productVersion;
 
-    public ProductGeneratorEntity(SCMLocator scm, String name, GAV gav, String productVersion) {
-        super(scm, name, gav);
+    public ProductGeneratorEntity(SCMLocator scm, int id, GAV gav, String productVersion) {
+        super(scm, id, gav);
 
         this.productVersion = productVersion;
     }

--- a/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectGeneratorEntity.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/model/ProjectGeneratorEntity.java
@@ -11,8 +11,8 @@ import org.jboss.da.reports.api.SCMLocator;
 @ToString
 public class ProjectGeneratorEntity extends GeneratorEntity {
 
-    public ProjectGeneratorEntity(SCMLocator scm, String name, GAV gav) {
-        super(scm, name, gav);
+    public ProjectGeneratorEntity(SCMLocator scm, int id, GAV gav) {
+        super(scm, id, gav);
     }
 
     public static EntityConstructor<ProjectGeneratorEntity> getConstructor(){

--- a/bc-backend/src/test/java/org/jboss/da/bc/backend/impl/BuildConfigurationGeneratorImplTest.java
+++ b/bc-backend/src/test/java/org/jboss/da/bc/backend/impl/BuildConfigurationGeneratorImplTest.java
@@ -44,7 +44,7 @@ public class BuildConfigurationGeneratorImplTest {
     public void testValidBcName() throws Exception {
         ProductGeneratorEntity genEntity = prepareGeneratorEntity("testName-1_0");
         when(
-                finalizer.createBCs(genEntity.getName(), genEntity.getProductVersion(),
+                finalizer.createBCs(genEntity.getId(), genEntity.getProductVersion(),
                         genEntity.getToplevelBc(), genEntity.getBcSetName())).thenReturn(1);
 
         assertEquals(new Integer(1), bcGenerator.createBC(genEntity).get());
@@ -59,10 +59,10 @@ public class BuildConfigurationGeneratorImplTest {
         projectHierarchy.setSelected(true);
 
         ProductGeneratorEntity genEntity = new ProductGeneratorEntity(new SCMLocator("", "", ""),
-                null, null, null);
+                0, null, null);
         genEntity.setBcSetName("BCSetName");
         genEntity.setProductVersion("1.1");
-        genEntity.setName("ProductName");
+        genEntity.setId(0);
         genEntity.setToplevelBc(projectHierarchy);
         return genEntity;
     }

--- a/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProduct.java
@@ -47,7 +47,7 @@ public class BuildConfigurationsProduct extends
     @Override
     protected ProductInfoEntity start(SCMLocator scm, EntryEntity entry) throws ScmException,
             PomAnalysisException, CommunicationException {
-        ProductGeneratorEntity entity = bcg.startBCGeneration(scm, entry.getName(),
+        ProductGeneratorEntity entity = bcg.startBCGeneration(scm, entry.getId(),
                 entry.getProductVersion());
         return toInfoEntity(entity);
     }

--- a/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProject.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsProject.java
@@ -47,7 +47,7 @@ public class BuildConfigurationsProject extends
     @Override
     protected ProjectInfoEntity start(SCMLocator scm, EntryEntity entry) throws ScmException,
             PomAnalysisException, CommunicationException {
-        ProjectGeneratorEntity entity = bcg.startBCGeneration(scm, entry.getName());
+        ProjectGeneratorEntity entity = bcg.startBCGeneration(scm, entry.getId());
         return toInfoEntity(entity);
     }
 

--- a/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsREST.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/BuildConfigurationsREST.java
@@ -162,7 +162,7 @@ public abstract class BuildConfigurationsREST<I extends InfoEntity, O extends Fi
 
     protected void fillInfoEntity(InfoEntity ie, GeneratorEntity ge) {
         ie.setBcSetName(ge.getBcSetName());
-        ie.setName(ge.getName());
+        ie.setId(ge.getId());
         ie.setPomPath(ge.getPomPath());
         ie.setTopLevelBc(toBuildConfiguration(ge.getToplevelBc()));
     }
@@ -175,7 +175,7 @@ public abstract class BuildConfigurationsREST<I extends InfoEntity, O extends Fi
         SCMLocator scml = new SCMLocator(url, revision, path);
         GAV gav = ie.getTopLevelBc().getGav();
 
-        T ge = constructor.construct(scml, ie.getName(), gav);
+        T ge = constructor.construct(scml, ie.getId(), gav);
 
         ge.setBcSetName(ie.getBcSetName());
         ge.setToplevelBc(toProjectHiearchy(ie.getTopLevelBc()));

--- a/bc-rest/src/main/java/org/jboss/da/bc/model/EntryEntity.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/model/EntryEntity.java
@@ -33,7 +33,7 @@ public class EntryEntity {
 
     @Getter
     @Setter
-    protected String name;
+    protected int id;
 
     @Getter
     @Setter

--- a/bc-rest/src/main/java/org/jboss/da/bc/model/InfoEntity.java
+++ b/bc-rest/src/main/java/org/jboss/da/bc/model/InfoEntity.java
@@ -13,7 +13,7 @@ public class InfoEntity {
 
     @Getter
     @Setter
-    protected String name;
+    protected int id;
 
     @Getter
     @Setter

--- a/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/analyse-next-level/da-application-1.json
+++ b/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/analyse-next-level/da-application-1.json
@@ -1,5 +1,5 @@
 {
-    "name":"Dependency analysis",
+    "id":1,
     "pomPath":"application/pom.xml",
     "productVersion":"0.3",
     "topLevelBc":{

--- a/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/analyse-next-level/da-common-1.json
+++ b/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/analyse-next-level/da-common-1.json
@@ -1,5 +1,5 @@
 {
-    "name":"Dependency analysis",
+    "id":1,
     "pomPath":"common/pom.xml",
     "productVersion": "0.3",
     "topLevelBc":{

--- a/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/start-process/da-common.json
+++ b/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/start-process/da-common.json
@@ -1,5 +1,5 @@
 {
-    "name":"Dependency analysis",
+    "id":1,
     "pomPath":"common/pom.xml",
     "productVersion": "0.3",
     "topLevelBc":{

--- a/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/start-process/da-parent.json
+++ b/testsuite/src/test/rest/v-1.0/expectedResponse/build-configuration/generate/product/start-process/da-parent.json
@@ -1,5 +1,5 @@
 {
-    "name":"Dependency analysis",
+    "id":1,
     "pomPath":"pom.xml",
     "productVersion": "0.3",
     "topLevelBc":{

--- a/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/analyse-next-level/da-application-1.json
+++ b/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/analyse-next-level/da-application-1.json
@@ -1,5 +1,5 @@
 {
-    "name":"Dependency analysis",
+    "id":1,
     "bcSetName":"Build configuration set for org.jboss.da:application:0.3.0",
     "pomPath":"application/pom.xml",
     "productVersion": "0.3",

--- a/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/analyse-next-level/da-common-1.json
+++ b/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/analyse-next-level/da-common-1.json
@@ -1,5 +1,5 @@
 {
-    "name":"Dependency analysis",
+    "id":1,
     "bcSetName":"Build configuration set for org.jboss.da:common:0.3.0",
     "pomPath":"common/pom.xml",
     "productVersion": "0.3",

--- a/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/finish-process/da-parent.json
+++ b/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/finish-process/da-parent.json
@@ -1,5 +1,5 @@
 {
-    "name":"Dependency analysis - PLACEHOLDER",
+    "id":1,
     "bcSetName":"Build configuration set for org.jboss.da:parent:0.3.0",
     "pomPath":"pom.xml",
     "productVersion": "0.3",

--- a/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/start-process/da-common.json
+++ b/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/start-process/da-common.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dependency analysis",
+    "id":1,
     "scmUrl": "https://github.com/project-ncl/dependency-analysis.git",
     "pomPath": "common/pom.xml",
     "productVersion": "0.3",

--- a/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/start-process/da-parent.json
+++ b/testsuite/src/test/rest/v-1.0/request/build-configuration/generate/product/start-process/da-parent.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dependency analysis",
+    "id":1,
     "scmUrl": "https://github.com/project-ncl/dependency-analysis.git",
     "pomPath": "pom.xml",
     "productVersion": "0.3",


### PR DESCRIPTION
Instead of trying to create a product, we'll just assume that the
product already exists.

The REST call to the import endpoint doesn't change though. We'll still
have to send the product name.

We'll still try to create a product version if it hasn't been created
yet.