### PR TITLE
Fix uncorrected checking for missing entity.

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/pnc/impl/PNCConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/impl/PNCConnectorImpl.java
@@ -190,7 +190,7 @@ public class PNCConnectorImpl implements PNCConnector {
         ClientResponse<PNCResponseWrapper<List<BuildConfiguration>>> response = get(requestUrl,
                 new GenericType<PNCResponseWrapper<List<BuildConfiguration>>>() {}, accessToken);
 
-        if (response.getEntity() == null && response.getResponseStatus() == Status.NO_CONTENT)
+        if (response.getResponseStatus() == Status.NO_CONTENT)
             return Collections.emptyList();
         else
             return checkAndReturn(response, accessToken).getContent();


### PR DESCRIPTION
If an error occurs, an exception is thrown, that entity was already read