### PR TITLE
Refactor PomAnalyzerImpl and fix [DA-239] 

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/model/GAVDependencyTree.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/model/GAVDependencyTree.java
@@ -2,8 +2,16 @@ package org.jboss.da.communication.aprox.model;
 
 import org.jboss.da.communication.model.GAV;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,4 +36,51 @@ public class GAVDependencyTree {
         dependencies.add(dep);
     }
 
+    /**
+     * Prune duplicate subtrees leaving one instance for each duplicate.
+     */
+    public void prune(){
+        Map<GAV, Set<GAVDependencyTree>> forest = new HashMap<>();
+        fillForest(this, forest);
+        Map<GAV, Set<GAVDependencyTree>> candidates = forest.entrySet().stream()
+                .filter(e -> e.getValue().size() > 1)
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+              
+        int previous;
+        do{
+            previous = candidates.size();
+            pruneLeaves(this, candidates);
+        }while(!candidates.isEmpty() && previous > candidates.size());
+    }
+
+    private static void fillForest(GAVDependencyTree tree, Map<GAV, Set<GAVDependencyTree>> forest) {
+        Set<GAVDependencyTree> trees = forest.computeIfAbsent(tree.getGav(), (k) -> new HashSet<>());
+        trees.add(tree);
+        for(GAVDependencyTree t : tree.getDependencies()){
+            fillForest(t, forest);
+        }
+    }
+
+    private static void pruneLeaves(GAVDependencyTree tree,
+            Map<GAV, Set<GAVDependencyTree>> candidates) {
+        // Sort the dependencies by GAV so the prunnig will be deterministic
+        List<GAVDependencyTree> deps = new ArrayList<>(tree.getDependencies());
+        Collections.sort(deps, (a,b) -> a.gav.toString().compareTo(b.gav.toString()));
+
+        for (GAVDependencyTree d : deps) {
+            pruneLeaves(d, candidates);
+        }
+        Iterator<GAVDependencyTree> it = tree.getDependencies().iterator();
+        while (it.hasNext()) {
+            GAVDependencyTree d = it.next();
+            if (d.getDependencies().isEmpty() && candidates.containsKey(d.getGav())) {
+                it.remove();
+                Set<GAVDependencyTree> forest = candidates.get(d.getGav());
+                forest.remove(d);
+                if (forest.size() <= 1) {
+                    candidates.remove(d.getGav());
+                }
+            }
+        }
+    }
 }

--- a/communication/src/main/java/org/jboss/da/communication/pom/GalleyWrapper.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/GalleyWrapper.java
@@ -1,9 +1,16 @@
 package org.jboss.da.communication.pom;
 
+import org.commonjava.cartographer.CartoDataException;
+import org.commonjava.cartographer.graph.MavenModelProcessor;
+import org.commonjava.cartographer.graph.discover.DiscoveryConfig;
+import org.commonjava.cartographer.graph.discover.DiscoveryResult;
+import org.commonjava.maven.atlas.graph.rel.DependencyRelationship;
+import org.commonjava.maven.atlas.graph.rel.RelationshipType;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.galley.maven.GalleyMaven;
 import org.commonjava.maven.galley.maven.GalleyMavenException;
 import org.commonjava.maven.galley.maven.model.view.DependencyView;
+import org.commonjava.maven.galley.maven.model.view.MavenGAVView;
 import org.commonjava.maven.galley.maven.model.view.MavenPomView;
 import org.commonjava.maven.galley.maven.parse.MavenPomReader;
 import org.commonjava.maven.galley.maven.parse.PomPeek;
@@ -15,11 +22,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,12 +57,40 @@ public class GalleyWrapper implements AutoCloseable {
         locations.add(localRepo.getLocation());
     }
 
+    /**
+     * Return GalleyWrapper pointer to artifact specified in given pom.
+     * @param pomPath Path to the pom file relative to the scm repostiory root.
+     * @return GalleyWrapper "pointer" to an artifact.
+     * @throws PomAnalysisException 
+     */
     public Artifact getPom(String pomPath) throws PomAnalysisException {
         Artifact a = new Artifact(scm, pomPath);
         if (a.ref == null) {
             throw new PomAnalysisException("Could not analyse pom " + scm.resolve(pomPath));
         }
         return a;
+    }
+
+    /**
+     * Returns GalleyWrapper pointer to artifact representing given GAV.
+     * @param gav GAV of the artifact.
+     * @return GalleyWrapper "pointer" to an artifact.
+     * @throws org.jboss.da.communication.pom.PomAnalysisException
+     */
+    public Artifact getGAV(GAV gav) throws PomAnalysisException {
+        try {
+            for (Path p : LocalRepo.getAllPoms(scm)) {
+                PomPeek pp = new PomPeek(p.toFile());
+                if (pp.getKey() == null)
+                    continue;
+                if (gav.equals(generateGAV(pp.getKey()))) {
+                    return new Artifact(p);
+                }
+            }
+        } catch (IOException ex) {
+            throw new PomAnalysisException(ex);
+        }
+        throw new PomAnalysisException("Artifact " + gav + " was not found in repository");
     }
 
     /**
@@ -88,8 +127,29 @@ public class GalleyWrapper implements AutoCloseable {
     }
 
     /**
+     * Returns {@link MavenPomView} for given artifact.
+     * You need to set locations so the galley know where to look for dependencies.
+     * @param artifact
+     * @return MavenPomView of the artifact
+     * @throws org.jboss.da.communication.pom.PomAnalysisException
+     * @see #addCentralLocation()
+     * @see #addLocations(java.util.List)
+     * @see #addLocationsFromPoms(org.jboss.da.communication.pom.PomReader)
+     */
+    public MavenPomView getPomView(Artifact artifact) throws PomAnalysisException {
+        try {
+            return mvnPomReader.read(artifact.ref, locations);
+        } catch (GalleyMavenException ex) {
+            throw new PomAnalysisException(ex);
+        }
+    }
+
+    /**
      * Returns first level dependencies of an artifact.
      * You need to set locations so the galley know where to look for dependencies.
+     * @param artifact Dependencies of this artifact will be returned
+     * @return First level dependencies.
+     * @throws org.jboss.da.communication.pom.PomAnalysisException
      * @see #addCentralLocation()
      * @see #addLocations(java.util.List)
      * @see #addLocationsFromPoms(org.jboss.da.communication.pom.PomReader)
@@ -110,25 +170,22 @@ public class GalleyWrapper implements AutoCloseable {
                 .collect(Collectors.toSet());
     }
 
-    private static GAV generateGAV(DependencyView dep) {
-        try {
-            return new GAV(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
-        } catch (GalleyMavenException ex) {
-            log.warn("Failed to get gav of dependency " + dep, ex);
-            return null;
-        }
-    }
-
-    // private void addLocations(PomPeek pp, MavenPomView view){
-    // view.getAllRepositories();
-    // }
-
+    /**
+     * Add repositories Galley should use when resolving dependencies.
+     * @param repositories List of repository URLs.
+     */
     public void addLocations(List<String> repositories) {
         repositories.stream()
                 .map(repository -> new SimpleLocation(repository, repository))
                 .forEachOrdered(locations::add);
     }
 
+    /**
+     * Add repositories Gally should use when resolving dependencies by
+     * analysing pom files in SCM repository.
+     * @param pomReader instance of {@link PomReader} used for parsing pom files
+     * @throws IOException 
+     */
     public void addLocationsFromPoms(PomReader pomReader) throws IOException{
         Set<Path> allPoms = localRepo.getAllPoms();
         allPoms.stream()
@@ -142,7 +199,8 @@ public class GalleyWrapper implements AutoCloseable {
     }
 
     /**
-     * Add maven central repo to locations.
+     * Add maven central repository among repositories Gally should use when
+     * resolving dependencies.
      */
     public void addCentralLocation() {
         locations.add(new SimpleLocation("central", "http://repo.maven.apache.org/maven2/"));
@@ -153,6 +211,124 @@ public class GalleyWrapper implements AutoCloseable {
         localRepo.delete();
     }
 
+    /**
+     * Return all transitive dependencies of given artifact.
+     * Dependencies of test-scope and provided-scope dependencies are ommited.
+     * You need to set locations so the galley know where to look for dependencies.
+     * @param artifact Dependencies of this artifact will be returned
+     * @return Set of dependency relationships describing the dependency graph.
+     * @throws GalleyMavenException
+     * @throws CartoDataException 
+     * @see #addCentralLocation()
+     * @see #addLocations(java.util.List)
+     * @see #addLocationsFromPoms(org.jboss.da.communication.pom.PomReader)
+     */
+    public Set<DependencyRelationship> getAllDependencies(Artifact artifact)
+            throws GalleyMavenException, CartoDataException {
+        return getAllDependencies(artifact, false, false);
+    }
+
+    /**
+     * Return all transitive dependencies of given artifact.
+     * You need to set locations so the galley know where to look for dependencies.
+     * @param artifact Dependencies of this artifact will be returned
+     * @param testDeps true if should dependencies of test-scope dependency be
+     * resolved.
+     * @param providedDeps true if should dependencies of provided-scope
+     * dependency be resolved.
+     * @return Set of dependency relationships describing the dependency graph. 
+     * @throws GalleyMavenException
+     * @throws CartoDataException 
+     * @see #addCentralLocation()
+     * @see #addLocations(java.util.List)
+     * @see #addLocationsFromPoms(org.jboss.da.communication.pom.PomReader)
+     */
+    public Set<DependencyRelationship> getAllDependencies(Artifact artifact, boolean testDeps,
+            boolean providedDeps) throws GalleyMavenException, CartoDataException {
+        Set<DependencyRelationship> deps = new HashSet<>();
+
+        URI src = localRepo.getUri();
+        DiscoveryConfig disConf = new DiscoveryConfig(src);
+        disConf.setLocations(locations);
+        disConf.setIncludeBuildSection(false);
+        disConf.setIncludeManagedDependencies(false);
+        disConf.setIncludeManagedPlugins(false);
+        MavenModelProcessor processor = new MavenModelProcessor();
+
+        Queue<DependencyRelationship> work = new LinkedList<>();
+        work.addAll(getDeps(artifact.ref, processor, src, disConf));
+
+        while (!work.isEmpty()) {
+            DependencyRelationship dr = work.remove();
+            if (deps.contains(dr)) {
+                continue;
+            }
+            deps.add(dr);
+
+            if (!shouldAnalyzeDependencies(dr, testDeps, providedDeps))
+                continue;
+
+            try {
+                work.addAll(getDeps(dr.getTarget(), processor, src, disConf));
+            } catch (CartoDataException | GalleyMavenException ex) {
+                log.warn("Failed to get dependencies for " + dr.getTarget(), ex);
+            }
+        }
+        return deps;
+    }
+
+    private Set<DependencyRelationship> getDeps(ProjectVersionRef ref, MavenModelProcessor processor, URI src, DiscoveryConfig disConf) throws GalleyMavenException, CartoDataException{
+        MavenPomView pomView = mvnPomReader.read(ref, locations);
+        DiscoveryResult relationships = processor.readRelationships(pomView, src, disConf);
+        return relationships.getAcceptedRelationships().stream()
+                .filter(r -> r.getType() == RelationshipType.DEPENDENCY)
+                .map(r -> (DependencyRelationship) r)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Return true if scope is compile, runtime, test (when {@code testDeps} is
+     * true) or provided (when {@code providedDeps} is true).
+     * @param dr Dependency relationship which scope we compare.
+     * @param testDeps
+     * @param providedDeps
+     * @return 
+     */
+    public static boolean shouldAnalyzeDependencies(DependencyRelationship dr, boolean testDeps,
+            boolean providedDeps) {
+        switch (dr.getScope()) {
+            case _import:
+            case embedded:
+            case system:
+            case toolchain:
+                return false;
+            case test:
+                return testDeps;
+            case provided:
+                return providedDeps;
+            case compile:
+            case runtime:
+            default:
+                return true;
+        }
+    }
+
+    private static GAV generateGAV(MavenGAVView dep) {
+        try {
+            return new GAV(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
+        } catch (GalleyMavenException ex) {
+            log.warn("Failed to get gav of dependency " + dep, ex);
+            return null;
+        }
+    }
+
+    public static GAV generateGAV(ProjectVersionRef dep) {
+        return new GAV(dep.getGroupId(), dep.getArtifactId(), dep.getVersionString());
+    }
+
+    /**
+     * GalleyWrapper "pointer" to an arifact.
+     */
     public static class Artifact {
 
         private Path path;
@@ -170,7 +346,7 @@ public class GalleyWrapper implements AutoCloseable {
         }
 
         private Artifact(final Path basePath, final String pomPath) {
-            this(basePath.resolve(pomPath));
+            this(basePath.resolve(toRelative(pomPath)));
         }
 
         @Override
@@ -183,6 +359,14 @@ public class GalleyWrapper implements AutoCloseable {
                 throw new PomAnalysisException("Failed to get gav from " + path);
 
             return new GAV(ref.getGroupId(), ref.getArtifactId(), ref.getVersionString());
+        }
+
+        private static String toRelative(String path) {
+            if (path.startsWith("/")) {
+                return path.replaceFirst("/", "");
+            } else {
+                return path;
+            }
         }
     }
 }

--- a/communication/src/main/java/org/jboss/da/communication/pom/LocalRepo.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/LocalRepo.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
@@ -34,7 +35,11 @@ public class LocalRepo {
     }
 
     public synchronized Location getLocation() {
-        return new SimpleLocation(path.toUri().toString());
+        return new SimpleLocation(getUri().toString());
+    }
+
+    public synchronized URI getUri() {
+        return path.toUri();
     }
 
     private void initLocalRepo(GalleyMaven galley, Path scmDir) throws IOException {
@@ -60,7 +65,7 @@ public class LocalRepo {
         }
     }
 
-    private Set<Path> getAllPoms(Path scmDir) throws IOException {
+    public static Set<Path> getAllPoms(Path scmDir) throws IOException {
         return Files.walk(scmDir)
                 .filter(p -> !Files.isDirectory(p)) // is file
                 .filter(p -> p.endsWith("pom.xml")) // named pom.xml

--- a/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
@@ -1,20 +1,12 @@
 package org.jboss.da.communication.pom;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.maven.scm.ScmException;
 import org.commonjava.cartographer.CartoDataException;
 import org.commonjava.cartographer.CartographerCore;
-import org.commonjava.cartographer.graph.MavenModelProcessor;
-import org.commonjava.cartographer.graph.discover.DiscoveryConfig;
-import org.commonjava.cartographer.graph.discover.DiscoveryResult;
-import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
-import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
-import org.commonjava.maven.galley.TransferException;
+import org.commonjava.maven.atlas.graph.rel.DependencyRelationship;
 import org.commonjava.maven.galley.maven.GalleyMavenException;
 import org.commonjava.maven.galley.maven.model.view.MavenPomView;
 import org.commonjava.maven.galley.maven.parse.MavenPomReader;
 import org.commonjava.maven.galley.maven.parse.PomPeek;
-import org.commonjava.maven.galley.maven.util.ArtifactPathUtils;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.SimpleLocation;
 import org.jboss.da.common.CommunicationException;
@@ -25,11 +17,9 @@ import org.jboss.da.communication.aprox.model.GAVDependencyTree;
 import org.jboss.da.communication.model.GAV;
 import org.jboss.da.communication.pom.api.PomAnalyzer;
 import org.jboss.da.communication.pom.model.MavenProject;
-import org.jboss.da.communication.pom.model.MavenRepository;
 import org.jboss.da.communication.pom.qualifier.DACartographerCore;
 import org.jboss.da.communication.model.GA;
-import org.jboss.da.scm.api.SCM;
-import org.jboss.da.scm.api.SCMType;
+import org.jboss.da.communication.pom.impl.DependencyTreeBuilder;
 import org.slf4j.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -38,19 +28,13 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class PomAnalyzerImpl implements PomAnalyzer {
@@ -62,171 +46,83 @@ public class PomAnalyzerImpl implements PomAnalyzer {
     private PomReader pomReader;
 
     @Inject
-    private SCM scmManager;
-
-    @Inject
     @DACartographerCore
     private CartographerCore carto;
 
     @Inject
     private Configuration config;
 
+    @Inject
+    private DependencyTreeBuilder dtb;
+
     @Override
-    public GAVDependencyTree readRelationships(File pomRepoDir, File pomPath,
+    public GAVDependencyTree readRelationships(File pomRepoDir, String pomPath,
             List<String> repositories) throws PomAnalysisException {
 
-        try {
+        try (GalleyWrapper gw = new GalleyWrapper(carto.getGalley(), pomRepoDir)) {
+            GalleyWrapper.Artifact pom = gw.getPom(pomPath);
+            gw.addLocations(repositories);
 
-            // if pomPath is for e.g <tmp>/application/pom.xml instead of application,
-            // rectify this to '<tmp>/application'
-            if (pomPath.isFile() && pomPath.getName().equals("pom.xml")) {
-                pomPath = pomPath.getParentFile();
-            }
-
-            GAVDependencyTree root = null;
-
-            File tempDir = Files.createTempDirectory("deps").toFile();
-
-            Map<GAV, GAVDependencyTree> gavDependencyTreeMap = new HashMap<>();
-
-            try {
-                // map of file and ProjectVersionRefs that represent all the pom.xmls found in the pomRepoDir directory
-                Map<File, ProjectVersionRef> projectVersionRefs = getProjectVersionRefs(tempDir,
-                        findAllPomFiles(pomRepoDir));
-
-                // for each pom.xml
-                for (Map.Entry<File, ProjectVersionRef> entry : projectVersionRefs.entrySet()) {
-                    Set<ProjectRelationship<?, ?>> relationships;
-                    try {
-                        // find all the dependencies / plugins / parents / plugins etc for each pom.xml
-                        relationships = getDiscoveryResult(tempDir, pomRepoDir, entry.getValue(),
-                                repositories).getAcceptedRelationships();
-                    } catch (GalleyMavenException e) {
-                        log.warn("Could not parse pom file: " + entry.getKey(), e);
-                        continue;
-                    }
-
-                    // convert from ProjectVersionRef to GAV
-                    GAV originGAV = generateGAV(entry.getValue());
-
-                    // get the origin GAVDependencyTree
-                    GAVDependencyTree originScmGAVTree = addGAVDependencyTreeToMapper(
-                            gavDependencyTreeMap, originGAV);
-
-                    // need to use canonical path to get better way of knowing if 2 paths are the same
-                    if (pomPath.getCanonicalPath().equals(entry.getKey().getCanonicalPath()))
-                        root = originScmGAVTree;
-
-                    for (ProjectRelationship<?, ?> relationship : relationships) {
-                        ProjectVersionRef target = relationship.getTarget();
-
-                        GAV targetGAV = generateGAV(target);
-
-                        GAVDependencyTree targetScmGavTree = addGAVDependencyTreeToMapper(
-                                gavDependencyTreeMap, targetGAV);
-
-                        addTargetToGAVDependencyTree(originScmGAVTree, targetScmGavTree,
-                                relationship);
-                    }
-                }
-                if (root == null) {
-                    throw new PomAnalysisException("Root pom was not found in repository.");
-                }
-                return root;
-            } finally {
-                // cleanup
-                FileUtils.deleteDirectory(tempDir);
-            }
-        } catch (URISyntaxException | CartoDataException | IOException e) {
-            throw new PomAnalysisException(e);
+            return readRelationships(gw, pom);
+        } catch (IOException ex) {
+            throw new PomAnalysisException(ex);
         }
     }
 
     @Override
     public GAVDependencyTree readRelationships(File pomRepoDir, GAV gav)
             throws PomAnalysisException {
+        try (GalleyWrapper gw = new GalleyWrapper(carto.getGalley(), pomRepoDir)) {
+            GalleyWrapper.Artifact artifact = gw.getGAV(gav);
+
+            return readRelationships(gw, artifact);
+        } catch (IOException ex) {
+            throw new PomAnalysisException(ex);
+        }
+    }
+
+    private GAVDependencyTree readRelationships(GalleyWrapper gw, GalleyWrapper.Artifact a)
+            throws PomAnalysisException {
         try {
-            File tempDir = Files.createTempDirectory("deps").toFile();
-            try {
-                // map of file and ProjectVersionRefs that represent all the pom.xmls found in the pomRepoDir directory
-                Map<File, ProjectVersionRef> projectVersionRefs = getProjectVersionRefs(tempDir,
-                        findAllPomFiles(pomRepoDir));
+            gw.addCentralLocation();
+            gw.addLocationsFromPoms(pomReader);
 
-                File pomPath = null;
+            Set<DependencyRelationship> relationships = gw.getAllDependencies(a);
 
-                for (Map.Entry<File, ProjectVersionRef> entry : projectVersionRefs.entrySet()) {
-                    if (isProjectVersionRefSameAsGAV(entry.getValue(), gav)) {
-                        pomPath = entry.getKey();
-                        break;
-                    }
-                }
+            GAV originGAV = a.getGAV();
 
-                if (pomPath == null) {
-                    throw new PomAnalysisException("Could not find the GAV " + gav
-                            + " in the project");
-                } else {
-                    return readRelationships(pomRepoDir, pomPath, Collections.emptyList());
-                }
-
-            } finally {
-                FileUtils.deleteDirectory(tempDir);
-            }
-        } catch (IOException e) {
-            throw new PomAnalysisException(e);
+            return dtb.getDependencyTree(relationships, originGAV, false, false);
+        } catch (CartoDataException | GalleyMavenException | IOException ex) {
+            throw new PomAnalysisException(ex);
         }
     }
 
     @Override
     public Optional<File> getPOMFileForGAV(File pomRepoDir, GAV gav) {
-
-        return findAllPomFiles(pomRepoDir).stream()
-                .filter(file -> isProjectVersionRefSameAsGAV(file, gav))
-                .findAny();
-    }
-
-    /**
-     * Return an existing GAVDependencyTree if present in the map, otherwise create a new GAVDependencyTree
-     * and map the GAV to the GAVDependencyTree
-     *
-     * @param map
-     * @param gav
-     * @return
-     */
-    private GAVDependencyTree addGAVDependencyTreeToMapper(Map<GAV, GAVDependencyTree> map, GAV gav) {
-        return map.computeIfAbsent(gav, (k) -> new GAVDependencyTree(k));
-    }
-
-    private GAV generateGAV(ProjectVersionRef ref) {
-        return new GAV(ref.getGroupId(), ref.getArtifactId(), ref.getVersionString());
+        try{
+            return LocalRepo.getAllPoms(pomRepoDir.toPath()).stream()
+                    .filter(p -> isProjectVersionRefSameAsGAV(p, gav))
+                    .map(Path::toFile)
+                    .findAny();
+        }catch(IOException ex){
+            log.warn("Failed to find pom for GAV", ex);
+            return Optional.empty();
+        }
     }
 
     @Override
-    public List<MavenPomView> getGitPomView(String scmUrl, String revision, String pomPath,
-            List<String> repositories) throws PomAnalysisException {
-        File tempDir = null;
-        try {
-            File clonedDir = scmManager.cloneRepository(SCMType.GIT, scmUrl, revision);
+    public MavenPomView getGitPomView(File repoDir, String pomPath, List<String> repositories)
+            throws PomAnalysisException {
+        try (GalleyWrapper gw = new GalleyWrapper(carto.getGalley(), repoDir)) {
+            GalleyWrapper.Artifact pom = gw.getPom(pomPath);
+            gw.addCentralLocation();
+            gw.addLocationsFromPoms(pomReader);
+            gw.addLocations(repositories);
 
-            tempDir = Files.createTempDirectory("deps").toFile();
-
-            File pom = new File(clonedDir, pomPath);
-
-            Map<File, ProjectVersionRef> projectVersionRefs = getProjectVersionRefs(tempDir,
-                    Collections.singletonList(pom));
-            List<MavenPomView> poms = new ArrayList<>();
-            MavenPomReader mavenPomReader = carto.getGalley().getPomReader();
-            for (Map.Entry<File, ProjectVersionRef> entry : projectVersionRefs.entrySet()) {
-                poms.add(mavenPomReader.read(entry.getValue(),
-                        getRepoLocations(tempDir, clonedDir, repositories)));
-            }
-
-            return poms;
-        } catch (ScmException | IOException | GalleyMavenException e) {
-            log.warn(e.getMessage());
-        } finally {
-            FileUtils.deleteQuietly(tempDir);
+            return gw.getPomView(pom);
+        } catch (IOException ex) {
+            throw new PomAnalysisException(ex);
         }
-        return new ArrayList<>();
     }
 
     @Override
@@ -250,25 +146,6 @@ public class PomAnalyzerImpl implements PomAnalyzer {
         MavenPomView pomView = mavenPomReader.read(pom.getKey(), repos);
 
         return pomView;
-    }
-
-    private DiscoveryResult getDiscoveryResult(File tempDir, File repoDir, ProjectVersionRef ref,
-            List<String> repositories) throws GalleyMavenException, URISyntaxException,
-            CartoDataException {
-
-        MavenPomReader mavenPomReader = carto.getGalley().getPomReader();
-        MavenPomView pomView = mavenPomReader.read(ref,
-                getRepoLocations(tempDir, repoDir, repositories));
-
-        URI src = new URI(new SimpleLocation("file:" + tempDir.getAbsolutePath()).getUri());
-
-        DiscoveryConfig disConf = new DiscoveryConfig(src);
-        disConf.setIncludeBuildSection(false);
-        disConf.setIncludeManagedDependencies(false);
-        disConf.setIncludeManagedPlugins(false);
-
-        MavenModelProcessor processor = new MavenModelProcessor();
-        return processor.readRelationships(pomView, src, disConf);
     }
 
     @Override
@@ -299,117 +176,6 @@ public class PomAnalyzerImpl implements PomAnalyzer {
         }
     }
 
-    private List<Location> getRepoLocations(File cacheDir, File repoDir, List<String> repositories) {
-
-        List<Location> repoLocations = new LinkedList<>();
-        // add local location
-        repoLocations.add(new SimpleLocation("file:" + cacheDir.getAbsolutePath()));
-
-        // add maven central location
-        repoLocations.add(new SimpleLocation("central", "http://repo.maven.apache.org/maven2/"));
-
-        // add all the repositories mentioned in the pom.xml
-        List<SimpleLocation> locationsInPom = getLocationsDefinedInPom(repoDir);
-        repoLocations.addAll(locationsInPom);
-
-        if (repositories != null) {
-            repoLocations.addAll(repositories.stream()
-                    .map(repository -> new SimpleLocation(repository, repository))
-                    .collect(Collectors.toList()));
-        }
-
-        return repoLocations;
-    }
-
-    private List<SimpleLocation> getLocationsDefinedInPom(File repoDir) {
-
-        List<File> pomFilePaths = findAllPomFiles(repoDir);
-        List<SimpleLocation> locations = new LinkedList<>();
-
-        for (File pom : pomFilePaths) {
-            Optional<MavenProject> project = pomReader.analyze(pom);
-            if (project.isPresent() && project.get().getMavenRepositories() != null) {
-                for (MavenRepository repo : project.get().getMavenRepositories()) {
-                    locations.add(new SimpleLocation(repo.getId(), repo.getUrl()));
-                }
-            }
-        }
-
-        return locations;
-    }
-
-    /**
-     * Given the locations of the pom.xml files, setup the tempDir into a structure
-     * where Cartographer will be able to analyze the poms, and return back a
-     * list of ProjectVersionRefs objects generated from the pom.xml files.
-     * @param tempDir
-     * @param poms
-     * @return
-     * @throws TransferException
-     * @throws IOException
-     */
-    private Map<File, ProjectVersionRef> getProjectVersionRefs(File tempDir, List<File> poms)
-            throws IOException {
-
-        Map<File, ProjectVersionRef> projectVersionRefs = new HashMap<>();
-
-        for (File pomFile : poms) {
-            PomPeek peek = new PomPeek(pomFile);
-            if (peek.getKey() == null) {
-                log.warn("Could not parse " + pomFile.getAbsolutePath());
-                continue;
-            }
-
-            try {
-                String path = ArtifactPathUtils.formatArtifactPath(peek.getKey().asPomArtifact(),
-                        carto.getGalley().getTypeMapper());
-                projectVersionRefs.put(pomFile.getParentFile().getAbsoluteFile(), peek.getKey());
-
-                File f = new File(tempDir, path);
-                Files.createDirectories(f.getParentFile().toPath());
-                FileUtils.copyFile(pomFile, f);
-            } catch (TransferException | RuntimeException ex) {
-                log.warn("Could not parse " + pomFile.getAbsolutePath(), ex);
-            }
-        }
-        return projectVersionRefs;
-    }
-
-    /**
-     * Return all the pom.xml paths found under the folderDir directory
-     *
-     * @param folderDir directory to analyze dependencies
-     * @return List of the pom.xml files
-     */
-    private List<File> findAllPomFiles(File folderDir) {
-
-        Collection<File> pomFilePaths = FileUtils
-                .listFiles(folderDir, new String[] { "xml" }, true);
-
-        List<File> paths = pomFilePaths.stream()
-                .filter(f -> f.getName().equals("pom.xml"))
-                .collect(Collectors.toList());
-
-        return paths;
-    }
-
-    /**
-     * Based on the target type, add the target to one of the fields in 'origin'
-     * @param origin
-     * @param target
-     * @param relationship
-     */
-    private void addTargetToGAVDependencyTree(GAVDependencyTree origin, GAVDependencyTree target,
-            ProjectRelationship<?, ?> relationship) {
-        switch (relationship.getType()) {
-            case DEPENDENCY:
-                origin.addDependency(target);
-                break;
-            default:
-                break;
-        }
-    }
-
     @Override
     public Optional<MavenProject> readPom(File pomPath) {
         return pomReader.analyze(pomPath);
@@ -420,23 +186,14 @@ public class PomAnalyzerImpl implements PomAnalyzer {
         return pomReader.analyze(is);
     }
 
-    private boolean isProjectVersionRefSameAsGAV(ProjectVersionRef f, GAV gav) {
-        String version = f.getVersionString();
-        String groupId = f.getGroupId();
-        String artifactId = f.getArtifactId();
-
-        return gav.getGroupId().equals(groupId) && gav.getArtifactId().equals(artifactId)
-                && gav.getVersion().equals(version);
-    }
-
-    private boolean isProjectVersionRefSameAsGAV(File file, GAV gav) {
-
-        PomPeek pk = new PomPeek(file);
+    private boolean isProjectVersionRefSameAsGAV(Path file, GAV gav) {
+        PomPeek pk = new PomPeek(file.toFile());
 
         if (pk.getKey() == null) {
             return false;
         } else {
-            return isProjectVersionRefSameAsGAV(pk.getKey(), gav);
+            return gav.equals(GalleyWrapper.generateGAV(pk.getKey()));
         }
     }
+
 }

--- a/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
@@ -98,6 +98,20 @@ public class PomAnalyzerImpl implements PomAnalyzer {
     }
 
     @Override
+    public Set<GAV> getToplevelDepency(File pomRepoDir, GAV gav) throws PomAnalysisException {
+        try (GalleyWrapper gw = new GalleyWrapper(carto.getGalley(), pomRepoDir)) {
+            GalleyWrapper.Artifact artifact = gw.getGAV(gav);
+
+            gw.addCentralLocation();
+            gw.addLocationsFromPoms(pomReader);
+
+            return gw.getDependencies(artifact);
+        } catch (IOException ex) {
+            throw new PomAnalysisException(ex);
+        }
+    }
+
+    @Override
     public Optional<File> getPOMFileForGAV(File pomRepoDir, GAV gav) {
         try{
             return LocalRepo.getAllPoms(pomRepoDir.toPath()).stream()

--- a/communication/src/main/java/org/jboss/da/communication/pom/api/PomAnalyzer.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/api/PomAnalyzer.java
@@ -39,7 +39,7 @@ public interface PomAnalyzer {
      * @return The GAVDependencyTree of the root project
      * @throws PomAnalysisException
      */
-    GAVDependencyTree readRelationships(File pomRepoDir, File pomPath, List<String> repositories)
+    GAVDependencyTree readRelationships(File pomRepoDir, String pomPath, List<String> repositories)
             throws PomAnalysisException;
 
     /**
@@ -59,8 +59,8 @@ public interface PomAnalyzer {
     public Map<GA, Set<GAV>> getDependenciesOfModules(File scmDir, String pomPath,
             List<String> repositories) throws PomAnalysisException;
 
-    public List<MavenPomView> getGitPomView(String scmUrl, String revision, String pomPath,
-            List<String> repositories) throws PomAnalysisException;
+    public MavenPomView getGitPomView(File repoDir, String pomPath, List<String> repositories)
+            throws PomAnalysisException;
 
     public MavenPomView getMavenPomView(InputStream is) throws ConfigurationParseException,
             GalleyMavenException;

--- a/communication/src/main/java/org/jboss/da/communication/pom/api/PomAnalyzer.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/api/PomAnalyzer.java
@@ -54,6 +54,18 @@ public interface PomAnalyzer {
      */
     GAVDependencyTree readRelationships(File pomRepoDir, GAV gav) throws PomAnalysisException;
 
+    /**
+     * Given the directory of a project, and the gav of the project which
+     * we'll consider as the root project, return the GAVDependencyTree of the
+     * root project.
+     *
+     * @param pomRepoDir Directory of the project to analyze
+     * @param gav GAV of the root project to analyze
+     * @return The GAVDependencyTree of the root project
+     * @throws PomAnalysisException
+     */
+    Set<GAV> getToplevelDepency(File pomRepoDir, GAV gav) throws PomAnalysisException;
+
     public Optional<File> getPOMFileForGAV(File tempDir, GAV gav);
 
     public Map<GA, Set<GAV>> getDependenciesOfModules(File scmDir, String pomPath,

--- a/communication/src/main/java/org/jboss/da/communication/pom/impl/DependencyTreeBuilder.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/impl/DependencyTreeBuilder.java
@@ -1,0 +1,162 @@
+package org.jboss.da.communication.pom.impl;
+
+import org.commonjava.maven.atlas.graph.rel.DependencyRelationship;
+import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
+import org.jboss.da.communication.aprox.model.GAVDependencyTree;
+import org.jboss.da.communication.model.GAV;
+import org.jboss.da.communication.pom.GalleyWrapper;
+import org.slf4j.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ *
+ * @author Honza Brázdil <janinko.g@gmail.com>
+ */
+@ApplicationScoped
+public class DependencyTreeBuilder {
+
+    @Inject
+    private Logger log;
+
+    /**
+     * Transforms DependencyRelationships into GAVDependencyTree.
+     */
+    public GAVDependencyTree getDependencyTree(Set<DependencyRelationship> rels, GAV origin, boolean testDeps, boolean providedDeps){
+        PathNode pathRoot = new PathNode(origin);
+        Map<GAV, Set<DependencyRelationship>> byGav = new HashMap<>();
+
+        for(DependencyRelationship rel : rels){
+            GAV gav = GalleyWrapper.generateGAV(rel.getDeclaring());
+            Set<DependencyRelationship> deps = byGav.computeIfAbsent(gav, (k) -> new HashSet<>());
+            deps.add(rel);
+        }
+        
+        walkDependencies(pathRoot, byGav, testDeps, providedDeps);
+
+        GAVDependencyTree depRoot = new GAVDependencyTree(pathRoot.gav);
+        constructDepTree(depRoot, pathRoot);
+        depRoot.prune();
+        return depRoot;
+    }
+
+    private void constructDepTree(GAVDependencyTree depTree, PathNode pathTree) {
+        for (PathNode child : pathTree.childs) {
+            GAVDependencyTree d = new GAVDependencyTree(child.gav);
+            depTree.addDependency(d);
+            constructDepTree(d, child);
+        }
+    }
+
+    private void walkDependencies(PathNode root, Map<GAV, Set<DependencyRelationship>> byGav,
+            boolean testDeps, boolean providedDeps) {
+        Set<DependencyRelationship> rels = byGav.get(root.gav);
+
+        if (rels == null)
+            return;
+
+        for (DependencyRelationship d : rels) {
+            ArtifactRef target = d.getTarget();
+            GAV targetGav = GalleyWrapper.generateGAV(target);
+
+            if (root.exclude(target))
+                continue; // Avoid excluded
+
+            PathNode pn = new PathNode(root, targetGav);
+            pn.addExcludes(d.getExcludes());
+
+            root.addChild(pn);
+
+            if (pn.parents.contains(targetGav)) {
+                log.warn("Found cyclic dependency: " + root.gav + " -> " + targetGav);
+                continue; // Avoid cycle
+            }
+
+            // When test (provided) dependencies are ommited, GalleyWrapper
+            // should handle this in most cases when retrieving relationships,
+            // however in scenario like this:
+            // ' a
+            // ' |- b test
+            // ' | |- c compile
+            // ' |- d compile
+            // ' |- b compile
+            // ' |- c compile
+            // GalleyWrapper will return relationship b->c (because of path
+            // a-d-b) and we must ensure that path a-b will ommit c when test
+            // (provided) dependencies are to be ommited.
+            if (!GalleyWrapper.shouldAnalyzeDependencies(d, testDeps, providedDeps))
+                continue;
+
+            walkDependencies(pn, byGav, testDeps, providedDeps);
+        }
+
+    }
+
+    private static class PathNode {
+
+        private final Set<GAV> parents = new HashSet<>();
+
+        private final Set<ProjectRef> excludes = new HashSet<>();
+
+        private final GAV gav;
+
+        private final Set<PathNode> childs = new HashSet<>();
+
+        public PathNode(GAV gav) {
+            this.gav = gav;
+        }
+
+        public PathNode(PathNode parent, GAV gav) {
+            parents.addAll(parent.parents);
+            parents.add(parent.gav);
+            excludes.addAll(parent.excludes);
+            this.gav = gav;
+        }
+
+        public void addExcludes(Set<ProjectRef> excludes) {
+            this.excludes.addAll(excludes);
+        }
+
+        public boolean exclude(ProjectRef ref){
+            return excludes.stream().anyMatch(ex -> ex.matches(ref));
+        }
+
+        public void addChild(PathNode pn) {
+            childs.add(pn);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 5;
+            hash = 89 * hash + Objects.hashCode(this.parents);
+            hash = 89 * hash + Objects.hashCode(this.gav);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final PathNode other = (PathNode) obj;
+            if (!Objects.equals(this.parents, other.parents)) {
+                return false;
+            }
+            if (!Objects.equals(this.gav, other.gav)) {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/communication/src/main/java/org/jboss/da/communication/scm/api/SCMConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/scm/api/SCMConnector.java
@@ -61,6 +61,19 @@ public interface SCMConnector {
             throws ScmException, PomAnalysisException;
 
     /**
+     * Finds toplevel dependency of specific revision on scm url
+     *
+     * @param scmUrl
+     * @param revision
+     * @param gav
+     * @return Dependencies of revision
+     * @throws PomAnalysisException When there is problem with the pom analysis
+     * @throws ScmException When checking out the repository failed
+     */
+    Set<GAV> getToplevelDependencyOfRevision(String scmUrl, String revision, GAV gav)
+            throws ScmException, PomAnalysisException;
+
+    /**
      * Returns true when GAV is in given repository.
      *
      * @param scmUrl

--- a/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
@@ -47,6 +47,17 @@ public class SCMConnectorImpl implements SCMConnector {
     }
 
     @Override
+    public Set<GAV> getToplevelDependencyOfRevision(String scmUrl, String revision, GAV gav)
+            throws ScmException, PomAnalysisException {
+        // git clone
+        // TODO: hardcoded to git right now
+        // TODO: enable the svn test if svn support is added
+        File tempDir = scmManager.cloneRepository(SCMType.GIT, scmUrl, revision);
+
+        return pomAnalyzer.getToplevelDepency(tempDir, gav);
+    }
+
+    @Override
     public GAVDependencyTree getDependencyTreeOfRevision(String scmUrl, String revision,
             String pomPath, List<String> repositories) throws ScmException, PomAnalysisException {
         // git clone

--- a/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/scm/impl/SCMConnectorImpl.java
@@ -54,8 +54,8 @@ public class SCMConnectorImpl implements SCMConnector {
         // TODO: enable the svn test if svn support is added
         File tempDir = scmManager.cloneRepository(SCMType.GIT, scmUrl, revision);
 
-        GAVDependencyTree gavDependencyTree = pomAnalyzer.readRelationships(tempDir, new File(
-                tempDir, pomPath), repositories);
+        GAVDependencyTree gavDependencyTree = pomAnalyzer.readRelationships(tempDir, pomPath,
+                repositories);
 
         return gavDependencyTree;
     }

--- a/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/backend/impl/DependencyTreeGeneratorImpl.java
@@ -68,8 +68,8 @@ public class DependencyTreeGeneratorImpl implements DependencyTreeGenerator {
     @Override
     public GAVToplevelDependencies getToplevelDependencies(String url, String revision, GAV gav)
             throws ScmException, PomAnalysisException {
-        GAVDependencyTree tree = getDependencyTree(url, revision, gav);
-        return treeToToplevel(tree);
+        Set<GAV> deps = scmConnector.getToplevelDependencyOfRevision(url, revision, gav);
+        return new GAVToplevelDependencies(gav, deps);
     }
 
     private GAVToplevelDependencies treeToToplevel(GAVDependencyTree tree){

--- a/testsuite/src/test/rest/v-1.0/expectedResponse/reports/scm/dependency-analysis.json
+++ b/testsuite/src/test/rest/v-1.0/expectedResponse/reports/scm/dependency-analysis.json
@@ -1,58 +1,228 @@
 {
-  "groupId": "org.jboss.da",
-  "artifactId": "common",
-  "version": "0.1.0",
-  "availableVersions": [],
-  "bestMatchVersion": null,
-  "dependencyVersionsSatisfied": false,
-  "dependencies": [
-    {
-      "groupId": "com.fasterxml.jackson.core",
-      "artifactId": "jackson-databind",
-      "version": "2.4.4",
-      "availableVersions": [],
-      "bestMatchVersion": null,
-      "dependencyVersionsSatisfied": true,
-      "dependencies": [],
-      "blacklisted": false,
-      "whitelisted": [],
-      "notBuiltDependencies": 0
-    },
-    {
-      "groupId": "junit",
-      "artifactId": "junit",
-      "version": "4.11",
-      "availableVersions": [
-        "4.10-redhat-2",
-        "4.11-redhat-1"
-      ],
-      "bestMatchVersion": "4.11-redhat-1",
-      "dependencyVersionsSatisfied": true,
-      "dependencies": [],
-      "blacklisted": false,
-      "whitelisted": [],
-      "notBuiltDependencies": 0
-    },
-    {
-      "groupId": "javax.enterprise",
-      "artifactId": "cdi-api",
-      "version": "1.2",
-      "availableVersions": [
-        "1.0-SP4-redhat-4",
-        "1.0-SP4.redhat-3",
-        "1.0.0.SP4-redhat-5",
-        "1.0-SP4-redhat-1",
-        "1.0-SP4-redhat-2"
-      ],
-      "bestMatchVersion": null,
-      "dependencyVersionsSatisfied": true,
-      "dependencies": [],
-      "blacklisted": false,
-      "whitelisted": [],
-      "notBuiltDependencies": 0
-    }
-  ],
-  "blacklisted": false,
-  "whitelisted": [],
-  "notBuiltDependencies": 2
+    "groupId": "org.jboss.da",
+    "artifactId": "common",
+    "version": "0.1.0",
+    "availableVersions": [],
+    "bestMatchVersion": null,
+    "dependencyVersionsSatisfied": false,
+    "dependencies": [
+        {
+            "groupId": "com.fasterxml.jackson.core",
+            "artifactId": "jackson-databind",
+            "version": "2.4.4",
+            "availableVersions": [],
+            "bestMatchVersion": null,
+            "dependencyVersionsSatisfied": false,
+            "dependencies": [
+                {
+                    "groupId": "com.fasterxml.jackson.core",
+                    "artifactId": "jackson-annotations",
+                    "version": "2.4.0",
+                    "availableVersions": [
+                    ],
+                    "bestMatchVersion": null,
+                    "dependencyVersionsSatisfied": true,
+                    "dependencies": [
+                    ],
+                    "blacklisted": false,
+                    "whitelisted": [
+                    ],
+                    "notBuiltDependencies": 0
+                },
+                {
+                    "groupId": "org.hibernate",
+                    "artifactId": "hibernate-cglib-repack",
+                    "version": "2.1_3",
+                    "availableVersions": [
+                    ],
+                    "bestMatchVersion": null,
+                    "dependencyVersionsSatisfied": true,
+                    "dependencies": [
+                    ],
+                    "blacklisted": false,
+                    "whitelisted": [
+                    ],
+                    "notBuiltDependencies": 0
+                },
+                {
+                    "groupId": "com.fasterxml.jackson.core",
+                    "artifactId": "jackson-core",
+                    "version": "2.4.4",
+                    "availableVersions": [
+                    ],
+                    "bestMatchVersion": null,
+                    "dependencyVersionsSatisfied": true,
+                    "dependencies": [
+                    ],
+                    "blacklisted": false,
+                    "whitelisted": [
+                    ],
+                    "notBuiltDependencies": 0
+                },
+                {
+                    "groupId": "org.codehaus.groovy",
+                    "artifactId": "groovy",
+                    "version": "1.7.9",
+                    "availableVersions": [
+                    ],
+                    "bestMatchVersion": null,
+                    "dependencyVersionsSatisfied": true,
+                    "dependencies": [
+                    ],
+                    "blacklisted": false,
+                    "whitelisted": [
+                    ],
+                    "notBuiltDependencies": 0
+                },
+                {
+                    "groupId": "junit",
+                    "artifactId": "junit",
+                    "version": "4.8.2",
+                    "availableVersions": [
+                        "4.10-redhat-2",
+                        "4.11-redhat-1"
+                    ],
+                    "bestMatchVersion": null,
+                    "dependencyVersionsSatisfied": true,
+                    "dependencies": [
+                    ],
+                    "blacklisted": false,
+                    "whitelisted": [
+                    ],
+                    "notBuiltDependencies": 0
+                },
+                {
+                    "groupId": "cglib",
+                    "artifactId": "cglib",
+                    "version": "2.2.2",
+                    "availableVersions": [
+                    ],
+                    "bestMatchVersion": null,
+                    "dependencyVersionsSatisfied": true,
+                    "dependencies": [
+                    ],
+                    "blacklisted": false,
+                    "whitelisted": [
+                    ],
+                    "notBuiltDependencies": 0
+                }
+            ],
+            "blacklisted": false,
+            "whitelisted": [],
+            "notBuiltDependencies": 6
+        },
+        {
+            "groupId": "junit",
+            "artifactId": "junit",
+            "version": "4.11",
+            "availableVersions": [
+                "4.10-redhat-2",
+                "4.11-redhat-1"
+            ],
+            "bestMatchVersion": "4.11-redhat-1",
+            "dependencyVersionsSatisfied": true,
+            "dependencies": [],
+            "blacklisted": false,
+            "whitelisted": [],
+            "notBuiltDependencies": 0
+        },
+        {
+            "groupId": "javax.enterprise",
+            "artifactId": "cdi-api",
+            "version": "1.2",
+            "availableVersions": [
+                "1.0-SP4-redhat-4",
+                "1.0-SP4.redhat-3",
+                "1.0.0.SP4-redhat-5",
+                "1.0-SP4-redhat-1",
+                "1.0-SP4-redhat-2"
+            ],
+            "bestMatchVersion": null,
+            "dependencyVersionsSatisfied": false,
+            "dependencies": [
+                {
+                    "groupId":"javax.el",
+                    "artifactId":"javax.el-api",
+                    "version":"3.0.0",
+                    "availableVersions":[
+
+                    ],
+                    "bestMatchVersion":null,
+                    "dependencyVersionsSatisfied":true,
+                    "dependencies":[
+
+                    ],
+                    "blacklisted":false,
+                    "whitelisted":[
+
+                    ],
+                    "notBuiltDependencies":0
+                },
+                {
+                    "groupId":"org.testng",
+                    "artifactId":"testng",
+                    "version":"5.10",
+                    "availableVersions":[
+                        "6.1.1-redhat-2"
+                    ],
+                    "bestMatchVersion":null,
+                    "dependencyVersionsSatisfied":true,
+                    "dependencies":[
+
+                    ],
+                    "blacklisted":false,
+                    "whitelisted":[
+
+                    ],
+                    "notBuiltDependencies":0
+                },
+                {
+                    "groupId":"javax.interceptor",
+                    "artifactId":"javax.interceptor-api",
+                    "version":"1.2",
+                    "availableVersions":[
+
+                    ],
+                    "bestMatchVersion":null,
+                    "dependencyVersionsSatisfied":true,
+                    "dependencies":[
+
+                    ],
+                    "blacklisted":false,
+                    "whitelisted":[
+
+                    ],
+                    "notBuiltDependencies":0
+                },
+                {
+                    "groupId":"javax.inject",
+                    "artifactId":"javax.inject",
+                    "version":"1",
+                    "availableVersions":[
+                        "1-redhat-3",
+                        "1.0.0.redhat-5",
+                        "1-redhat-2",
+                        "1-redhat-1",
+                        "1.redhat-4"
+                    ],
+                    "bestMatchVersion":"1.redhat-4",
+                    "dependencyVersionsSatisfied":true,
+                    "dependencies":[
+
+                    ],
+                    "blacklisted":false,
+                    "whitelisted":[
+
+                    ],
+                    "notBuiltDependencies":0
+                }
+            ],
+            "blacklisted": false,
+            "whitelisted": [],
+            "notBuiltDependencies": 3
+        }
+    ],
+    "blacklisted": false,
+    "whitelisted": [],
+    "notBuiltDependencies": 11
 }


### PR DESCRIPTION
Some functionality from PomAnalyzerImpl was trasnfered into GalleyWrapper.
Construction of DependencyTree was recreated and split into DependencyTreeBuilder.

Dependency on SCM was removed (SCM operation should be handled by caller methods).