### PR TITLE
Refactor BC object for PNC >= 0.9

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfigurationCreate.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfigurationCreate.java
@@ -61,7 +61,7 @@ public class BuildConfigurationCreate {
 
     @Getter
     @Setter
-    private List<Integer> productVersionIds;
+    private int productVersionId;
 
     public void setEnvironmentId(int id) {
         Environment env = new Environment();

--- a/testsuite/src/test/java/org/jboss/da/test/server/communication/PncRemoteTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/server/communication/PncRemoteTest.java
@@ -56,6 +56,7 @@ public class PncRemoteTest {
     @Test
     public void testCreateRemoveBC() throws Exception {
         String bcName = "BCTestName-" + UUID.randomUUID().toString();
+        String scmRepoUrl = "http://test-" + UUID.randomUUID().toString() + ".com";
         int environmentId = 1;
         int projectId = 1;
 
@@ -63,6 +64,8 @@ public class PncRemoteTest {
         bc.setName(bcName);
         bc.setEnvironmentId(environmentId);
         bc.setProjectId(projectId);
+        bc.setScmRepoURL(scmRepoUrl);
+        bc.setProductVersionId(1);
 
         // Create a BC
         BuildConfiguration obtainedBc = pncConnector.createBuildConfiguration(bc);


### PR DESCRIPTION
The BuildConfiguration JSON object provided by PNC for creating new BuildConfiguration has changed.

The productVersionId and scmRepoUrl fields have become mandatory, and we can only associate a buildConfiguration with only one productVersion. This change is required for #274 to pass its testsuite.