### PR TITLE
Workaround for FileAlreadyExistsException in LocalRepo

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/pom/LocalRepo.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/LocalRepo.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
@@ -61,6 +62,10 @@ public class LocalRepo {
                 Files.copy(pomFile, p);
             } catch (TransferException | RuntimeException ex) {
                 log.warn("Could not parse " + pomFile.toAbsolutePath(), ex);
+            } catch (FileAlreadyExistsException ex) {
+                log.error("File already exists. This is because there are multiple file with same "
+                        + "GAV. This ususaly happens when there are pom files in tests and is "
+                        + "harmless in this case.", ex);
             }
         }
     }


### PR DESCRIPTION
When there are several pomfiles in SCM repository with the same GAV,
there is FileAlreadyExistsException when creating LocalRepo pom cache.
This is usually harmless, as it happens only when there are pom files
e.g. in tests.