### PR TITLE
[NCL-2048] Use two repository groups

### DIFF
--- a/common/src/main/java/org/jboss/da/common/json/DAConfig.java
+++ b/common/src/main/java/org/jboss/da/common/json/DAConfig.java
@@ -42,6 +42,10 @@ public class DAConfig extends AbstractModuleConfig {
 
     @Getter
     @Setter
+    private String aproxGroupPublic;
+
+    @Getter
+    @Setter
     private String backupScmUrl;
 
     @Getter

--- a/common/src/main/resources/da-config.json
+++ b/common/src/main/resources/da-config.json
@@ -24,6 +24,7 @@
           "pncServer": "",
           "aproxServer": "",
           "aproxGroup": "",
+          "aproxGroupPublic": "",
           "backupScmUrl": "",
           "backupScmBranch": "",
           "repourUrl": ""

--- a/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/api/AproxConnector.java
@@ -25,7 +25,7 @@ public interface AproxConnector {
      * @param gav
      * @return Dependency tree of GAV
      * @throws CommunicationException When there is problem with communication.
-     *         FindGAVDependencyException if the GAV cannot be analyzed
+     * @throws FindGAVDependencyException if the GAV cannot be analyzed
      */
     GAVDependencyTree getDependencyTreeOfGAV(GAV gav) throws CommunicationException,
             FindGAVDependencyException;

--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -75,7 +75,7 @@ public class AproxConnectorImpl implements AproxConnector {
             ProjectGraphRequest req = mod
                     .newProjectGraphRequest()
                     .withWorkspaceId("export-" + rootRef.toString())
-                    .withSource("group:public")
+                    .withSource("group:" + config.getConfig().getAproxGroupPublic())
                     .withPatcherIds(DepgraphPatcherConstants.ALL_PATCHERS)
                     .withResolve(true)
                     .withGraph(
@@ -137,7 +137,8 @@ public class AproxConnectorImpl implements AproxConnector {
         try {
             DAConfig cfg = this.config.getConfig();
             query.append(cfg.getAproxServer());
-            query.append("/api/group/public/");
+            query.append("/api/group/");
+            query.append(cfg.getAproxGroupPublic()).append('/');
             query.append(gav.getGroupId().replace(".", "/")).append("/");
             query.append(gav.getArtifactId()).append('/');
             query.append(gav.getVersion()).append('/');
@@ -249,7 +250,8 @@ public class AproxConnectorImpl implements AproxConnector {
         try {
             DAConfig config = this.config.getConfig();
             query.append(config.getAproxServer());
-            query.append("/api/group/public/");
+            query.append("/api/group/");
+            query.append(config.getAproxGroupPublic()).append('/');
             query.append(gav.getGroupId().replace(".", "/")).append("/");
             query.append(gav.getArtifactId()).append('/');
             query.append(gav.getVersion()).append('/');

--- a/communication/src/main/java/org/jboss/da/communication/pom/GalleyWrapper.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/GalleyWrapper.java
@@ -206,10 +206,9 @@ public class GalleyWrapper implements AutoCloseable {
      * resolving dependencies.
      */
     public void addDefaultLocations(Configuration config) {
-        locations.add(new SimpleLocation("central", "http://repo.maven.apache.org/maven2/"));
         try {
             locations.add(new SimpleLocation("indy", config.getConfig().getAproxServer()
-                    + "/api/group/" + config.getConfig().getAproxGroup() + "/"));
+                    + "/api/group/" + config.getConfig().getAproxGroupPublic() + "/"));
         } catch (ConfigurationParseException e) {
             log.error("Failed to add indy group to locations" + e);
         }

--- a/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/PomAnalyzerImpl.java
@@ -150,7 +150,9 @@ public class PomAnalyzerImpl implements PomAnalyzer {
         StringBuilder query = new StringBuilder();
         DAConfig cfg = this.config.getConfig();
         query.append(cfg.getAproxServer());
-        query.append("/api/group/public/");
+        query.append("/api/group/");
+        query.append(config.getConfig().getAproxGroupPublic());
+        query.append('/');
         Location repoLocation = new SimpleLocation(query.toString());
 
         List<Location> repos = new ArrayList<>();


### PR DESCRIPTION
Use 'aproxGroup' repository for -redhat version finding.
Use 'aproxGroupPublic' for dependency search.