### PR TITLE
Allow exclude test from commandline

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -142,6 +142,9 @@
                         <arquillianPortConfig>-Djboss.socket.binding.port-offset=100
                             -Djboss.management.native.port=9054</arquillianPortConfig>
                     </systemProperties>
+                    <excludes>
+                        <exclude>${testsuite.test.excludes}</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
E.g. to exclude BugReporoducerRemoteTest use:
  -Dtestsuite.test.excludes=**/BugReporoducerRemoteTest.java