### PR TITLE
Add workaround for getting id of new build configurations

### DIFF
--- a/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
+++ b/bc-backend/src/main/java/org/jboss/da/bc/backend/impl/FinalizerImpl.java
@@ -20,8 +20,7 @@ import org.jboss.da.common.CommunicationException;
 import org.jboss.da.communication.pnc.api.PNCConnector;
 import org.jboss.da.communication.pnc.api.PNCRequestException;
 import org.jboss.da.communication.pnc.model.BuildConfiguration;
-import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
-import org.jboss.da.scm.api.SCMType;
+import org.jboss.da.communication.pnc.model.BuildConfigurationBPMCreate;
 import org.slf4j.Logger;
 
 /**
@@ -100,7 +99,7 @@ public class FinalizerImpl implements Finalizer {
                 
                 bc = optionalBc.orElseThrow(() -> new IllegalStateException("useExistingBC is true, but there is no BC to use."));
             } else {
-                BuildConfigurationCreate bcc = toBC(project, nextLevelDependencyIds);
+                BuildConfigurationBPMCreate bcc = toBC(project, nextLevelDependencyIds);
                 if (project.isCloneRepo()) {
                     log.warn("Repository clonning is disabled. (Tried to clone " + project.getScmUrl() + " " +project.getScmRevision());
                 }
@@ -114,8 +113,8 @@ public class FinalizerImpl implements Finalizer {
         }
     }
 
-    private BuildConfigurationCreate toBC(ProjectDetail project, Set<Integer> deps) {
-        BuildConfigurationCreate bc = new BuildConfigurationCreate();
+    private BuildConfigurationBPMCreate toBC(ProjectDetail project, Set<Integer> deps) {
+        BuildConfigurationBPMCreate bc = new BuildConfigurationBPMCreate();
         bc.setBuildScript(project.getBuildScript());
         bc.setDependencyIds(new ArrayList<>(deps));
         bc.setDescription(project.getDescription());

--- a/bc-backend/src/test/java/org/jboss/da/bc/backend/impl/FinalizerImplTest.java
+++ b/bc-backend/src/test/java/org/jboss/da/bc/backend/impl/FinalizerImplTest.java
@@ -6,7 +6,7 @@ import org.jboss.da.common.CommunicationException;
 import org.jboss.da.communication.pnc.api.PNCConnector;
 import org.jboss.da.communication.pnc.api.PNCRequestException;
 import org.jboss.da.communication.pnc.model.BuildConfiguration;
-import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
+import org.jboss.da.communication.pnc.model.BuildConfigurationBPMCreate;
 import org.jboss.da.model.rest.GAV;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,7 +53,7 @@ public class FinalizerImplTest {
      */
     @Test
     public void testCreateAllSelected() throws CommunicationException, PNCRequestException {
-        when(pnc.createBuildConfiguration(Matchers.any(BuildConfigurationCreate.class))).then(
+        when(pnc.createBuildConfiguration(Matchers.any(BuildConfigurationBPMCreate.class))).then(
                 new BCCAnswer());
         ProjectHiearchy root = getHiearchy(true);
         root.setDependencies(new HashSet<>(Arrays.asList(getHiearchy(true), getHiearchy(true))));
@@ -67,7 +67,7 @@ public class FinalizerImplTest {
      * integers, when the hiearchy object is not selected AND it has selected dependencies
      */
     public void testCreateRootNotSelected() throws CommunicationException, PNCRequestException {
-        when(pnc.createBuildConfiguration(Matchers.any(BuildConfigurationCreate.class))).then(
+        when(pnc.createBuildConfiguration(Matchers.any(BuildConfigurationBPMCreate.class))).then(
                 new BCCAnswer());
         ProjectHiearchy root = getHiearchy(false);
         root.setDependencies(new HashSet<>(Arrays.asList(getHiearchy(true), getHiearchy(true))));
@@ -81,7 +81,7 @@ public class FinalizerImplTest {
      * integer, when the hiearchy object is not selected AND it has NO selected dependencies
      */
     public void testCreateNothingSelected() throws CommunicationException, PNCRequestException {
-        when(pnc.createBuildConfiguration(Matchers.any(BuildConfigurationCreate.class))).then(
+        when(pnc.createBuildConfiguration(Matchers.any(BuildConfigurationBPMCreate.class))).then(
                 new BCCAnswer());
         ProjectHiearchy root = getHiearchy(false);
         root.setDependencies(new HashSet<>(Arrays.asList(getHiearchy(true), getHiearchy(true))));

--- a/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/api/PNCConnector.java
@@ -2,7 +2,7 @@ package org.jboss.da.communication.pnc.api;
 
 import org.jboss.da.common.CommunicationException;
 import org.jboss.da.communication.pnc.model.BuildConfiguration;
-import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
+import org.jboss.da.communication.pnc.model.BuildConfigurationBPMCreate;
 import org.jboss.da.communication.pnc.model.BuildConfigurationSet;
 import org.jboss.da.communication.pnc.model.Product;
 import org.jboss.da.communication.pnc.model.ProductVersion;
@@ -31,7 +31,18 @@ public interface PNCConnector {
     List<BuildConfiguration> getBuildConfigurations(String scmUrl, String scmRevision)
             throws CommunicationException, PNCRequestException;
 
-    BuildConfiguration createBuildConfiguration(BuildConfigurationCreate bc)
+    /**
+     * Gets BuildConfiguration from PNC with the specific name
+     *
+     * @param name name of the BC
+     * @return BC with specified name or empty optional if no such BC was found
+     * @throws CommunicationException Thrown if communication with PNC failed
+     * @throws PNCRequestException Thrown if PNC returns an error
+     */
+    Optional<BuildConfiguration> getBuildConfiguration(String name) throws CommunicationException,
+            PNCRequestException;
+
+    BuildConfiguration createBuildConfiguration(BuildConfigurationBPMCreate bc)
             throws CommunicationException, PNCRequestException;
 
     /**

--- a/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfigurationBPMCreate.java
+++ b/communication/src/main/java/org/jboss/da/communication/pnc/model/BuildConfigurationBPMCreate.java
@@ -1,0 +1,79 @@
+package org.jboss.da.communication.pnc.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BuildConfigurationBPMCreate {
+
+    @Getter
+    @Setter
+    @NonNull
+    private String name;
+
+    @Getter
+    @Setter
+    private String description;
+
+    @Getter
+    @Setter
+    private String buildScript;
+
+    @Getter
+    private String scmRepoURL;
+
+    @Getter
+    private String scmRevision;
+
+    @Getter
+    private String scmExternalRepoURL;
+
+    @Getter
+    private String scmExternalRevision;
+
+    @Getter
+    @Setter
+    private Integer project;
+
+    @Getter
+    @Setter
+    private Integer environment;
+
+    @Getter
+    @Setter
+    private List<Integer> dependencyIds;
+
+    @Getter
+    @Setter
+    private Integer productVersionId;
+
+    public void setEnvironmentId(int id) {
+        this.environment = id;
+    }
+
+    public void setProjectId(int id) {
+        this.project = id;
+    }
+
+    public void setSCMLocation(String repoURL, String revision) {
+        if (repoURL == null) {
+            repoURL = "";
+        }
+        if (!repoURL.contains("code.engineering.redhat.com")
+                && !repoURL.contains("git.app.eng.bos.redhat.com")) {
+            this.scmExternalRepoURL = repoURL;
+            this.scmExternalRevision = revision;
+        } else {
+            this.scmRepoURL = repoURL;
+            this.scmRevision = revision;
+        }
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/da/test/server/communication/PncRemoteTest.java
+++ b/testsuite/src/test/java/org/jboss/da/test/server/communication/PncRemoteTest.java
@@ -6,7 +6,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.da.communication.pnc.api.PNCConnector;
 import org.jboss.da.communication.pnc.model.BuildConfiguration;
-import org.jboss.da.communication.pnc.model.BuildConfigurationCreate;
 import org.jboss.da.test.ArquillianDeploymentFactory;
 import org.jboss.da.test.ArquillianDeploymentFactory.DepType;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -16,7 +15,6 @@ import org.junit.runner.RunWith;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Remote tests, which tests communication with PNC


### PR DESCRIPTION
Because creating BuildConfigurations using BPM process doesn't return id
of the newly createted BuildConfiguration, we need to get the id in some
other way. For now we will poll PNC until the BC is created, in the
future we should use websockets to retrieve a notification about BC
being created.