### PR TITLE
Relax GAV validation, allow dash in group id

### DIFF
--- a/reports-model/src/main/java/org/jboss/da/model/rest/GA.java
+++ b/reports-model/src/main/java/org/jboss/da/model/rest/GA.java
@@ -13,7 +13,7 @@ import lombok.NonNull;
 public class GA implements Comparable<GA> {
 
     private static final Pattern GROUP_ID_PATTERN = Pattern
-            .compile("([a-zA-Z_][a-zA-Z\\d_]*\\.)*[a-zA-Z_][a-zA-Z\\d_]*");
+            .compile("([a-zA-Z_][a-zA-Z\\d_-]*\\.)*[a-zA-Z_][a-zA-Z\\d_-]*");
 
     private static final Pattern ARTIFACT_ID_PATTERN = Pattern.compile("[a-zA-Z0-9_.-]+");
 

--- a/testsuite/src/test/rest/v-1/expectedResponse/build-configuration/generate/product/analyse-next-level/da-application-1.json
+++ b/testsuite/src/test/rest/v-1/expectedResponse/build-configuration/generate/product/analyse-next-level/da-application-1.json
@@ -343,10 +343,7 @@
                         "projectId":null,
                         "buildScript":"",
                         "description":"Build Configuration for commons-logging:commons-logging:1.1.1 - Commons Logging.",
-                        "internallyBuilt":null,
-                        "availableVersions":[
-
-                        ],
+                        "internallyBuilt":"1.1.1.redhat-3",
                         "bcId":null,
                         "gav":{
                             "groupId":"commons-logging",


### PR DESCRIPTION
Although maven specification prohibits it, maven doesn't enfore it.
That means considerable amount of project with dash in groupId exists.