### PR TITLE
(version-1.2.x) Use correct auth header

### DIFF
--- a/cli-wrap/src/main/resources/cli/da_cli_script.py
+++ b/cli-wrap/src/main/resources/cli/da_cli_script.py
@@ -61,7 +61,7 @@ def auth():
         MY_TOKEN = get_token(login, pswd)
         store_local_token(MY_TOKEN)
 
-    session.headers.update({'Authorization': " Bearer " + MY_TOKEN})
+    session.headers.update({'Authorization': "Bearer " + MY_TOKEN})
     return session
     
 def find_local_token():


### PR DESCRIPTION
With a leading space on the Authorization key, the requests library
doesn't like it and throws:

```
[pkocandr@vlk-ntb cli]$ ./da-cli.py add whitelist-product EAP:7.0.3 SUPPORTED
Using stored auth token.
Traceback (most recent call last):
  File "./da-cli.py", line 423, in <module>
    CLITool()
  File "./da-cli.py", line 182, in __init__
    getattr(self, args.command.replace("-","_"))()
  File "./da-cli.py", line 191, in add
    getattr(self, "add_"+args.color.replace("-","_"))()
  File "./da-cli.py", line 311, in add_whitelist_product
    self.listings.addWhitelistProd(sys.argv[3], sys.argv[4])
  File "/home/petr/workspace/git/dependency-analysis/cli-wrap/src/main/resources/cli/listings.py", line 22, in addWhitelistProd
    da_cli_script.add_artifacts(None, "whitelist-product", product, status)
  File "/home/petr/workspace/git/dependency-analysis/cli-wrap/src/main/resources/cli/da_cli_script.py", line 187, in add_artifacts
    add_whitelist_product(product, status)
  File "/home/petr/workspace/git/dependency-analysis/cli-wrap/src/main/resources/cli/da_cli_script.py", line 337, in add_whitelist_product
    r = requests_post(da_server + endpoint, json_request=json_request, login = True)
  File "/home/petr/workspace/git/dependency-analysis/cli-wrap/src/main/resources/cli/da_cli_script.py", line 98, in requests_post
    return requests_wrapper(session.post, link, json_request)
  File "/home/petr/workspace/git/dependency-analysis/cli-wrap/src/main/resources/cli/da_cli_script.py", line 114, in requests_wrapper
    reply = requests_method("http://"+link, json=json_request)
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 535, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 474, in request
    prep = self.prepare_request(req)
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 407, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/lib/python3.6/site-packages/requests/models.py", line 303, in prepare
    self.prepare_headers(headers)
  File "/usr/lib/python3.6/site-packages/requests/models.py", line 443, in prepare_headers
    check_header_validity(header)
  File "/usr/lib/python3.6/site-packages/requests/utils.py", line 793, in check_header_validity
    raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
requests.exceptions.InvalidHeader: Invalid return character or leading space in header: Authorization
```

When removing the leading whitespace on 'Bearer', the request succeeds:

```
➜  cli git:(version-1.2.x) ✗ ./da-cli.py add whitelist-product EAP:7.0.3 SUPPORTED
Using stored auth token.
➜  cli git:(version-1.2.x) ✗
```