### PR TITLE
Rework requests to Indy in lookup/gavs not to be duplicated for the same GA - 1.2

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -65,7 +65,7 @@ public class AproxConnectorImpl implements AproxConnector {
             return Collections.emptyList();
         } catch (IOException | ConfigurationParseException | CommunicationException e) {
             throw new CommunicationException("Failed to obtain versions for " + ga.toString()
-                    + " from approx server with url " + query.toString(), e);
+                    + " from Indy server with url " + query.toString(), e);
         }
     }
 
@@ -98,7 +98,7 @@ public class AproxConnectorImpl implements AproxConnector {
             return Optional.empty();
         } catch (IOException | ConfigurationParseException e) {
             throw new CommunicationException("Failed to obtain pom for " + gav.toString()
-                    + " from approx server with url " + query.toString(), e);
+                    + " from Indy server with url " + query.toString(), e);
         }
     }
 
@@ -136,7 +136,7 @@ public class AproxConnectorImpl implements AproxConnector {
             }
 
         } catch (IOException | ConfigurationParseException e) {
-            throw new CommunicationException("Failed to establish a connection with Aprox: "
+            throw new CommunicationException("Failed to establish a connection with Indy: "
                     + query.toString(), e);
         }
     }

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -266,17 +266,17 @@ public class ReportsGeneratorImplTest {
         LookupGAVsRequest request = new LookupGAVsRequest(new HashSet<>(), new HashSet<>(), gavs);
 
         // When
-        List<GAV> distinctedList = new ArrayList<>();
-        request.getGavs().stream()
-                .distinct()
-                .forEach((gav) -> {
-                    System.out.println("GAV: " + gav);
-                    distinctedList.add(gav);
-        });
+        List<GAV> uniqueGAVs = new ArrayList<>();
+        uniqueGAVs.add(new GAV("org", "test", "1.0"));
+        uniqueGAVs.add(new GAV("org", "test", "1.1"));
+        uniqueGAVs.add(new GAV("org2", "test2", "2.0"));
+        uniqueGAVs.add(new GAV("org2", "test2", "2.2"));
+
+        List<GAV> distinctList = request.getGavs().stream().distinct().collect(Collectors.toList());
 
         //Then
-        assertEquals(new HashSet<>(gavs).size(), distinctedList.size());
-        assertTrue(new HashSet<>(gavs).containsAll(distinctedList));
+        assertEquals(uniqueGAVs.size(), distinctList.size());
+        assertTrue(uniqueGAVs.equals(distinctList));
     }
 
     private void assertMultipleDependencies(Set<ArtifactReport> deps) {

--- a/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
+++ b/reports-backend/src/test/java/org/jboss/da/reports/impl/ReportsGeneratorImplTest.java
@@ -27,6 +27,8 @@ import org.jboss.da.reports.backend.api.DependencyTreeGenerator;
 import org.jboss.da.reports.backend.api.VersionFinder;
 import org.jboss.da.reports.backend.impl.DependencyTreeGeneratorImpl;
 import org.jboss.da.reports.model.rest.GAVRequest;
+import org.jboss.da.reports.model.rest.LookupGAVsRequest;
+import org.jboss.da.reports.model.rest.LookupReport;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -36,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -244,6 +247,36 @@ public class ReportsGeneratorImplTest {
         assertFalse(report.isBlacklisted());
         assertTrue(report.getWhitelisted().isEmpty());
         assertMultipleDependencies(report.getDependencies());
+    }
+
+    /**
+     * Test the distinct on a stream in #getLookupReportsForGavs works correctly
+     */
+    @Test
+    public void testDistinctOnGavsStream() {
+        // Given
+        List<GAV> gavs = new ArrayList<>();
+        gavs.add(new GAV("org", "test", "1.0"));
+        gavs.add(new GAV("org", "test", "1.1"));
+        gavs.add(new GAV("org", "test", "1.0"));
+
+        gavs.add(new GAV("org2", "test2", "2.0"));
+        gavs.add(new GAV("org2", "test2", "2.2"));
+        gavs.add(new GAV("org2", "test2", "2.0"));
+        LookupGAVsRequest request = new LookupGAVsRequest(new HashSet<>(), new HashSet<>(), gavs);
+
+        // When
+        List<GAV> distinctedList = new ArrayList<>();
+        request.getGavs().stream()
+                .distinct()
+                .forEach((gav) -> {
+                    System.out.println("GAV: " + gav);
+                    distinctedList.add(gav);
+        });
+
+        //Then
+        assertEquals(new HashSet<>(gavs).size(), distinctedList.size());
+        assertTrue(new HashSet<>(gavs).containsAll(distinctedList));
     }
 
     private void assertMultipleDependencies(Set<ArtifactReport> deps) {

--- a/reports-model/src/main/java/org/jboss/da/reports/model/rest/LookupGAVsRequest.java
+++ b/reports-model/src/main/java/org/jboss/da/reports/model/rest/LookupGAVsRequest.java
@@ -1,5 +1,6 @@
 package org.jboss.da.reports.model.rest;
 
+import lombok.ToString;
 import org.jboss.da.model.rest.GAV;
 
 import java.util.HashSet;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @RequiredArgsConstructor
+@ToString
 public class LookupGAVsRequest {
 
     @Getter

--- a/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/reports/Reports.java
@@ -35,6 +35,7 @@ import io.swagger.annotations.ApiResponses;
 
 import org.jboss.da.validation.ValidationException;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
@@ -188,13 +189,19 @@ public class Reports {
             @ApiParam(
                     value = "JSON list of objects with keys 'groupId', 'artifactId', and 'version'") LookupGAVsRequest gavRequest) {
         try {
-            return Response.status(Status.OK).entity(facade.gavsReport(gavRequest)).build();
+            log.info("Incoming request to /lookup/gavs. Payload: " + gavRequest.toString());
+            List<LookupReport> lookupReportList = facade.gavsReport(gavRequest);
+            log.info("Request to /lookup/gavs completed successfully. Payload: "
+                    + gavRequest.toString());
+            return Response.status(Status.OK).entity(lookupReportList).build();
         } catch (CommunicationException e) {
+            log.info("Request to /lookup/gavs failed! Reason: ", e);
             return Response
                     .status(502)
                     .entity(new ErrorMessage(ErrorMessage.eType.COMMUNICATION_FAIL,
                             "Communication with remote repository failed")).build();
         } catch (IllegalArgumentException e) {
+            log.info("Request to /lookup/gavs failed! Reason: ", e);
             return Response
                     .status(Status.INTERNAL_SERVER_ERROR)
                     .entity(new ErrorMessage(ErrorMessage.eType.ILLEGAL_ARGUMENTS,


### PR DESCRIPTION
This PR is related to #448, applying changes based on Honza's comments in the PR.

* The last 4 commits in #448  has been squashed.
* The test was rewritten to explicitly list the unique GAVs we are expecting, instead on relying on `HashSet` to find unique GAVs (this might get broken if `hashCode` and `equals` implementation in the `GAV` class is broken)