### PR TITLE
[NCL-3604][v1.2] Add retry for status 500 from Indy

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -55,9 +55,23 @@ public class AproxConnectorImpl implements AproxConnector {
             connection.setConnectTimeout(config.getAproxRequestTimeout());
 
             int retry = 0;
-            while (connection.getResponseCode() == 504 && retry < 5) {
-                connection = (HttpURLConnection) new URL(query.toString()).openConnection();
+            while ((connection.getResponseCode() == 504 || connection.getResponseCode() == 500)
+                    && retry < 2) {
+
+                log.warn("Connection to: {} failed with status: {}. retrying...", query.toString(),
+                        connection.getResponseCode());
+
                 retry++;
+
+                try {
+                    // Wait before retrying using Exponential back-off: 200ms, 400ms
+                    Thread.sleep((long) Math.pow(2, retry) * 100L);
+                } catch (InterruptedException e) {
+                    log.error(e.getMessage());
+                }
+
+                connection = (HttpURLConnection) new URL(query.toString()).openConnection();
+                connection.setConnectTimeout(config.getAproxRequestTimeout());
             }
 
             return parseMetadataFile(connection).getVersioning().getVersions().getVersion();


### PR DESCRIPTION
This commit also adds a retry for HTTP status 500 from Indy when
fetching the maven-metadata.xml file. This is in addition to the current
logic which is to retry on HTTP status 504.

This is done as Indy sometimes recovers from HTTP status 500 errors to
provide us with the right content (See NOS-1155).

This commit also adds a waiting time between retries; with the waiting
time determined by using an exponential backoff. This will hopefully
help the network/Indy recover from overload and provide the correct data
at a later time.