### PR TITLE
[NCL-3465] Add read timeout when communicating with Indy

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
+++ b/communication/src/main/java/org/jboss/da/communication/aprox/impl/AproxConnectorImpl.java
@@ -68,6 +68,7 @@ public class AproxConnectorImpl implements AproxConnector {
             HttpURLConnection connection = (HttpURLConnection) new URL(query.toString())
                     .openConnection();
             connection.setConnectTimeout(config.getAproxRequestTimeout());
+            connection.setReadTimeout(config.getAproxRequestTimeout());
 
             int retry = 0;
             while ((connection.getResponseCode() == 504 || connection.getResponseCode() == 500)
@@ -87,6 +88,7 @@ public class AproxConnectorImpl implements AproxConnector {
 
                 connection = (HttpURLConnection) new URL(query.toString()).openConnection();
                 connection.setConnectTimeout(config.getAproxRequestTimeout());
+                connection.setReadTimeout(config.getAproxRequestTimeout());
             }
 
             final List<String> versions = parseMetadataFile(connection).getVersioning()


### PR DESCRIPTION
We had only ConnectTimeout set but that's only for initial socket
connection, we also need read timeout if we want to timeout when indy
takes a long time to respond.