### PR TITLE
Add metrics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,16 @@
     - Open 'Arquillian' tab under the run configuration to set properties (jbossHome, managementPort)
 
   - Run/Debug your run configuration
+
+
+### Metrics support
+
+PNC tracks metrics of JVM and its internals via Dropwizard Metrics. The metrics can currently be reported to a Graphite server by specifying as system property or environment variables those properties:
+- metrics\_graphite\_server (mandatory)
+- metrics\_graphite\_port (mandatory)
+- metrics\_graphite\_prefix (mandatory)
+- metrics\_graphite\_interval (optional)
+
+If the `metrics_graphite_interval` variable (interval specified in seconds) is not specified, we'll use the default value of 60 seconds to report data to Graphite.
+
+The graphite reporter is configured to report rates per second and durations in terms of milliseconds.

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.da</groupId>
+            <artifactId>metrics</artifactId>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.da</groupId>
             <artifactId>reports-rest</artifactId>
             <type>war</type>
         </dependency>
@@ -78,6 +83,10 @@
                         <ejbModule>
                             <groupId>org.jboss.da</groupId>
                             <artifactId>reports-backend</artifactId>
+                        </ejbModule>
+                        <ejbModule>
+                            <groupId>org.jboss.da</groupId>
+                            <artifactId>metrics</artifactId>
                         </ejbModule>
                         <webModule>
                             <groupId>org.jboss.da</groupId>

--- a/application/src/main/application/META-INF/application.xml
+++ b/application/src/main/application/META-INF/application.xml
@@ -23,6 +23,9 @@
         <ejb>reports-backend.jar</ejb>
     </module>
     <module>
+        <ejb>metrics.jar</ejb>
+    </module>
+    <module>
         <web>
             <web-uri>reports-rest.war</web-uri>
             <context-root>da</context-root>

--- a/application/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/application/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -27,6 +27,7 @@
         <dependencies>
             <module name="deployment.dependency-analysis.ear.common.jar"/>
             <module name="deployment.dependency-analysis.ear.source-code-manager.jar"/>
+            <module name="deployment.dependency-analysis.ear.metrics.jar"/>
             <module name="org.keycloak.keycloak-core"/>
         </dependencies>
     </sub-deployment>

--- a/application/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/application/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -18,6 +18,10 @@
             <module name="deployment.dependency-analysis.ear.reports-model.jar"/>
         </dependencies>
     </sub-deployment>
+    <sub-deployment name="metrics.jar">
+        <dependencies>
+        </dependencies>
+    </sub-deployment>
     <sub-deployment name="communication.jar">
         <dependencies>
             <module name="deployment.dependency-analysis.ear.common.jar"/>

--- a/application/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/application/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -5,6 +5,7 @@
     <sub-deployment name="reports-rest.war">
         <dependencies>
             <module name="deployment.dependency-analysis.ear.reports-backend.jar"/>
+            <module name="deployment.dependency-analysis.ear.metrics.jar"/>
         </dependencies>
     </sub-deployment>
     <sub-deployment name="reports-model.jar">

--- a/communication/pom.xml
+++ b/communication/pom.xml
@@ -26,6 +26,11 @@
             <type>ejb</type>
         </dependency>
         <dependency>
+            <groupId>org.jboss.da</groupId>
+            <artifactId>metrics</artifactId>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>

--- a/communication/src/test/java/org/jboss/da/communication/aprox/AproxConnectorTest.java
+++ b/communication/src/test/java/org/jboss/da/communication/aprox/AproxConnectorTest.java
@@ -6,6 +6,7 @@ import org.jboss.da.common.util.Configuration;
 import org.jboss.da.common.util.ConfigurationParseException;
 import org.jboss.da.communication.aprox.impl.AproxConnectorImpl;
 import org.jboss.da.communication.pom.api.PomAnalyzer;
+import org.jboss.da.metrics.MetricsConfiguration;
 import org.jboss.da.model.rest.GA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +45,9 @@ public class AproxConnectorTest {
 
     @Mock
     private PomAnalyzer pomAnalyzer;
+
+    @Mock
+    private MetricsConfiguration metricsConfiguration;
 
     @InjectMocks
     private final AproxConnectorImpl dependencyTreeGenerator = new AproxConnectorImpl(config);

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2014 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>org.jboss.da</groupId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics</artifactId>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+
+        <!-- EJB spec -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+        </dependency>
+
+        <!-- Dropwizard deps -->
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics/src/main/java/org/jboss/da/metrics/MetricsConfiguration.java
+++ b/metrics/src/main/java/org/jboss/da/metrics/MetricsConfiguration.java
@@ -1,0 +1,192 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.da.metrics;
+
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.graphite.Graphite;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import lombok.Getter;
+import org.jboss.da.metrics.exceptions.NoPropertyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+@Startup
+public class MetricsConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(MetricsConfiguration.class);
+
+    private static final String METRIC_JVM_MEMORY = "jvm.memory";
+
+    private static final String METRIC_JVM_GARBAGE = "jvm.garbage";
+
+    private static final String METRIC_JVM_THREADS = "jvm.threads";
+
+    private static final String METRIC_JVM_CLASSLOADING = "jvm.classloading";
+
+    private static final String GRAPHITE_SERVER_KEY = "metrics_graphite_server";
+
+    private static final String GRAPHITE_PORT_KEY = "metrics_graphite_port";
+
+    private static final String GRAPHITE_PREFIX_KEY = "metrics_graphite_prefix";
+
+    // The interval is in seconds
+    private static final String GRAPHITE_INTERVAL_KEY = "metrics_graphite_interval";
+
+    private static final int DEFAULT_GRAPHITE_INTERVAL = 60;
+
+    @Getter
+    private MetricRegistry metricRegistry;
+
+    @PostConstruct
+    public void init() {
+
+        metricRegistry = new MetricRegistry();
+
+        monitorJvmMetrics();
+        setupGraphiteReporter();
+
+    }
+
+    /**
+     * If propertyName has no value (either specified in system property or environment property), then just return
+     * the default value. System property value has priority over environment property value.
+     * <p>
+     * If value can't be parsed, just return the default value.
+     *
+     * @param propertyName property name to check the value
+     * @param description  description to print in case value can't be parsed as an integer
+     * @return value from property, or throws NoPropertyException if property not specified
+     * @throws NoPropertyException if property not specified on system or env value
+     */
+    private String getValueFromProperty(String propertyName, String description)
+            throws NoPropertyException {
+
+        String value;
+
+        String valueSys = System.getProperty(propertyName);
+        String valueEnv = System.getenv(propertyName);
+
+        if (valueSys != null) {
+            value = valueSys;
+        } else if (valueEnv != null) {
+            value = valueEnv;
+        } else {
+            throw new NoPropertyException("Property '" + propertyName + "' not specified");
+        }
+
+        logger.info("Updated " + description + " to: " + value);
+
+        return value;
+    }
+
+    /**
+     * Add metrics for JVM. Already provided by metrics-jvm
+     */
+    private void monitorJvmMetrics() {
+
+        logger.info("Registering JVM metrics");
+
+        metricRegistry.register(METRIC_JVM_GARBAGE, new GarbageCollectorMetricSet());
+        metricRegistry.register(METRIC_JVM_MEMORY, new MemoryUsageGaugeSet());
+        metricRegistry.register(METRIC_JVM_THREADS, new ThreadStatesGaugeSet());
+        metricRegistry.register(METRIC_JVM_CLASSLOADING, new ClassLoadingGaugeSet());
+
+    }
+
+    /**
+     * Read system or environment variable to know to which Graphite server to report data to.
+     *
+     * If any of the required variables are not specified, abandon the setup and warn the user.
+     *
+     */
+    private void setupGraphiteReporter() {
+
+        int graphiteInterval = DEFAULT_GRAPHITE_INTERVAL;
+
+        try {
+
+            graphiteInterval = Integer.parseInt(getValueFromProperty(GRAPHITE_INTERVAL_KEY,
+                    "Graphite Interval reporting"));
+
+        } catch (NumberFormatException e) {
+
+            // thrown because we couldn't parse the interval as a number
+            logger.warn(
+                    "Could not parse Graphite interval! Using default value of {} seconds instead",
+                    DEFAULT_GRAPHITE_INTERVAL);
+
+        } catch (NoPropertyException e) {
+            // If we're here that property is not specified. Just continue using the default
+        }
+
+        try {
+
+            String graphiteServer = getValueFromProperty(GRAPHITE_SERVER_KEY, "Graphite Server URL");
+            int graphitePort = Integer.parseInt(getValueFromProperty(GRAPHITE_PORT_KEY,
+                    "Graphite Port"));
+            String graphitePrefix = getValueFromProperty(GRAPHITE_PREFIX_KEY, "Graphite Prefix");
+
+            startGraphiteReporter(graphiteServer, graphitePort, graphitePrefix, graphiteInterval);
+
+        } catch (NumberFormatException e) {
+
+            // thrown because it couldn't parse graphitePort
+            logger.warn("Could not parse Graphite port! Aborting reporting data to Graphite", e);
+
+        } catch (NoPropertyException e) {
+
+            logger.warn("Could not find property required to setup Graphite reporting! Reason: {}",
+                    e.getMessage());
+
+        }
+    }
+
+    /**
+     * Reporter of metrics to a Graphite server
+     *
+     * @param host   Graphite server
+     * @param port   Graphite port (usually 2003)
+     * @param prefix Prefix to use as a namespace for our logs
+     * @param interval interval at which to report metrics to Graphite in seconds
+     */
+    private void startGraphiteReporter(String host, int port, String prefix, int interval) {
+
+        logger.info("Setting up Graphite reporter");
+
+        Graphite graphite = new Graphite(new InetSocketAddress(host, port));
+
+        GraphiteReporter reporter = GraphiteReporter.forRegistry(metricRegistry)
+                .prefixedWith(prefix).convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS).filter(MetricFilter.ALL).build(graphite);
+
+        reporter.start(interval, TimeUnit.SECONDS);
+    }
+}

--- a/metrics/src/main/java/org/jboss/da/metrics/exceptions/NoPropertyException.java
+++ b/metrics/src/main/java/org/jboss/da/metrics/exceptions/NoPropertyException.java
@@ -1,0 +1,27 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.da.metrics.exceptions;
+
+public class NoPropertyException extends Exception {
+
+    public NoPropertyException(String message) {
+        super(message);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>reports-rest</module>
         <module>application</module>
         <module>cli-wrap</module>
+        <module>metrics</module>
     </modules>
 
     <developers>
@@ -109,31 +110,37 @@
             <dependency>
                 <groupId>org.jboss.da</groupId>
                 <artifactId>source-code-manager</artifactId>
-		<version>${project.version}</version>
+		        <version>${project.version}</version>
                 <type>ejb</type>
             </dependency>
             <dependency>
                 <groupId>org.jboss.da</groupId>
                 <artifactId>communication</artifactId>
-		<version>${project.version}</version>
+		        <version>${project.version}</version>
                 <type>ejb</type>
             </dependency>
             <dependency>
                 <groupId>org.jboss.da</groupId>
                 <artifactId>reports-model</artifactId>
-		<version>${project.version}</version>
+		        <version>${project.version}</version>
                 <type>ejb</type>
             </dependency>
             <dependency>
                 <groupId>org.jboss.da</groupId>
                 <artifactId>reports-backend</artifactId>
-		<version>${project.version}</version>
+		        <version>${project.version}</version>
+                <type>ejb</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.da</groupId>
+                <artifactId>metrics</artifactId>
+                <version>${project.version}</version>
                 <type>ejb</type>
             </dependency>
             <dependency>
                 <groupId>org.jboss.da</groupId>
                 <artifactId>reports-rest</artifactId>
-		<version>${project.version}</version>
+		        <version>${project.version}</version>
                 <type>war</type>
             </dependency>
             <!-- Project modules -->
@@ -303,6 +310,26 @@
                 <artifactId>wiremock-standalone</artifactId>
                 <version>2.6.0</version>
             </dependency>
+
+            <!-- Metrics dependencies -->
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jvm</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-graphite</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/reports-rest/pom.xml
+++ b/reports-rest/pom.xml
@@ -16,6 +16,12 @@
             <type>ejb</type>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.da</groupId>
+            <artifactId>metrics</artifactId>
+            <type>ejb</type>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/reports-rest/src/main/java/org/jboss/da/rest/ReportsRestActivator.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/ReportsRestActivator.java
@@ -1,6 +1,9 @@
 package org.jboss.da.rest;
 
 import org.jboss.da.rest.listings.Artifacts;
+import org.jboss.da.rest.metrics.GeneralRestMetricsFilter;
+import org.jboss.da.rest.metrics.TimedMetric;
+import org.jboss.da.rest.metrics.TimedMetricFilter;
 import org.jboss.da.rest.reports.Reports;
 
 import javax.ws.rs.ApplicationPath;
@@ -26,6 +29,7 @@ public class ReportsRestActivator extends Application {
         Set<Class<?>> resources = new HashSet<>();
         addSwaggerResources(resources);
         addProjectResources(resources);
+        addMetricsResources(resources);
         return resources;
     }
 
@@ -49,5 +53,11 @@ public class ReportsRestActivator extends Application {
         resources.add(Reports.class);
         resources.add(Products.class);
         resources.add(BlackListImpl.class);
+    }
+
+    public void addMetricsResources(Set<Class<?>> resources) {
+        resources.add(GeneralRestMetricsFilter.class);
+        resources.add(TimedMetric.class);
+        resources.add(TimedMetricFilter.class);
     }
 }

--- a/reports-rest/src/main/java/org/jboss/da/rest/metrics/GeneralRestMetricsFilter.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/metrics/GeneralRestMetricsFilter.java
@@ -1,0 +1,72 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.da.rest.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.jboss.da.metrics.MetricsConfiguration;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class GeneralRestMetricsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String METRICS_RATE_KEY = "da.rest.all.rate";
+
+    private static final String METRICS_TIMER_KEY = "da.rest.all.timer";
+
+    @Inject
+    private MetricsConfiguration metricsConfiguration;
+
+    @Inject
+    private HttpServletRequest servletRequest;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        MetricRegistry registry = metricsConfiguration.getMetricRegistry();
+
+        Timer timer = registry.timer(METRICS_TIMER_KEY);
+        Meter meter = registry.meter(METRICS_RATE_KEY);
+
+        Timer.Context counter = timer.time();
+        meter.mark();
+
+        servletRequest.setAttribute("timer.context", counter);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext,
+            ContainerResponseContext responseContext) throws IOException {
+
+        Timer.Context tc = (Timer.Context) servletRequest.getAttribute("timer.context");
+
+        if (tc != null) {
+            tc.stop();
+            servletRequest.removeAttribute("timer.context");
+        }
+    }
+}

--- a/reports-rest/src/main/java/org/jboss/da/rest/metrics/TimedMetric.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/metrics/TimedMetric.java
@@ -1,0 +1,33 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.da.rest.metrics;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate this to any REST method to get a timer and request rate of the particular method reported
+ */
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface TimedMetric {
+}

--- a/reports-rest/src/main/java/org/jboss/da/rest/metrics/TimedMetricFilter.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/metrics/TimedMetricFilter.java
@@ -1,0 +1,90 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.da.rest.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.jboss.da.metrics.MetricsConfiguration;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+@Provider
+@Priority(Priorities.USER)
+@TimedMetric
+public class TimedMetricFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String METRICS_KEY = "da.rest";
+
+    private static final String METRICS_RATE_KEY = ".rate";
+
+    private static final String METRICS_TIMER_KEY = ".timer";
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Inject
+    private MetricsConfiguration metricsConfiguration;
+
+    @Inject
+    private HttpServletRequest servletRequest;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        MetricRegistry registry = metricsConfiguration.getMetricRegistry();
+
+        String metricsName = METRICS_KEY
+                + name(resourceInfo.getResourceClass().getSimpleName(), resourceInfo
+                        .getResourceMethod().getName());
+
+        Timer timer = registry.timer(metricsName + METRICS_TIMER_KEY);
+        Meter meter = registry.meter(metricsName + METRICS_RATE_KEY);
+
+        Timer.Context counter = timer.time();
+        meter.mark();
+
+        servletRequest.setAttribute("timer.context.method", counter);
+
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext,
+            ContainerResponseContext responseContext) throws IOException {
+
+        Timer.Context tc = (Timer.Context) servletRequest.getAttribute("timer.context.method");
+
+        if (tc != null) {
+            tc.stop();
+            servletRequest.removeAttribute("timer.context.method");
+        }
+    }
+}

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -24,6 +24,11 @@
 	    	<artifactId>reports-backend</artifactId>
 	    	<type>ejb</type>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.da</groupId>
+            <artifactId>metrics</artifactId>
+            <type>ejb</type>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/testsuite/src/test/resources/META-INF/application.xml
+++ b/testsuite/src/test/resources/META-INF/application.xml
@@ -23,6 +23,9 @@
         <ejb>reports-backend.jar</ejb>
     </module>
     <module>
+        <ejb>metrics.jar</ejb>
+    </module>
+    <module>
         <web>
             <web-uri>reports-rest.war</web-uri>
             <context-root>testsuite</context-root>

--- a/testsuite/src/test/resources/META-INF/jboss-deployment-structure.xml
+++ b/testsuite/src/test/resources/META-INF/jboss-deployment-structure.xml
@@ -5,6 +5,7 @@
     <sub-deployment name="reports-rest.war">
         <dependencies>
             <module name="deployment.testsuite.ear.reports-backend.jar" export="true"/>
+            <module name="deployment.testsuite.ear.metrics.jar" export="true"/>
         </dependencies>
     </sub-deployment>
     <sub-deployment name="reports-model.jar">
@@ -18,10 +19,15 @@
             <module name="deployment.testsuite.ear.reports-model.jar" export="true"/>
         </dependencies>
     </sub-deployment>
+    <sub-deployment name="metrics.jar">
+        <dependencies>
+        </dependencies>
+    </sub-deployment>
     <sub-deployment name="communication.jar">
         <dependencies>
             <module name="deployment.testsuite.ear.common.jar" export="true"/>
             <module name="deployment.testsuite.ear.source-code-manager.jar" export="true"/>
+            <module name="deployment.testsuite.ear.metrics.jar" export="true"/>
             <module name="org.keycloak.keycloak-core"/>
         </dependencies>
     </sub-deployment>


### PR DESCRIPTION
This PR adds:
- Metrics support via Dropwizard Metrics for JVM and in-app instrumentation
- Add all REST req/s and timer
- Add support to instrument particular REST method via `@TimedMetric`
- Add timer for Apox/Indy client

![da_metrics](https://user-images.githubusercontent.com/630746/39892355-657af906-546e-11e8-83c9-63a7a01af5a8.png)