### PR TITLE
[NCL-4079] When version suffix is provided, use both provided and default

### DIFF
--- a/common/src/main/java/org/jboss/da/common/version/VersionParser.java
+++ b/common/src/main/java/org/jboss/da/common/version/VersionParser.java
@@ -11,6 +11,9 @@ public class VersionParser {
 
     private final String suffix;
 
+    private final Pattern defaultPattern = Pattern.compile("^" + RE_MMM + RE_QUALIFIER + "??"
+            + RE_SUFFIX_S + DEFAULT_SUFFIX + RE_SUFFIX_E + "$");
+
     private final Pattern versionPattern;
 
     // major.minor.micro.qualifier-suffix-X
@@ -30,7 +33,17 @@ public class VersionParser {
     }
 
     public SuffixedVersion parse(String version) {
-        Matcher versionMatcher = versionPattern.matcher(version);
+        SuffixedVersion suffixedVersion = parseVersion(versionPattern.matcher(version), version,
+                suffix);
+        if (!suffixedVersion.isSuffixed()) {
+            suffixedVersion = parseVersion(defaultPattern.matcher(version), version, DEFAULT_SUFFIX);
+        }
+
+        return suffixedVersion;
+    }
+
+    private SuffixedVersion parseVersion(Matcher versionMatcher, String version, String parseSuffix)
+            throws NumberFormatException, IllegalArgumentException {
         if (!versionMatcher.matches()) {
             throw new IllegalArgumentException("Version " + version + "is unparsable");
         }
@@ -48,7 +61,7 @@ public class VersionParser {
             return new SuffixedVersion(major, minor, micro, qualifier, version);
         } else {
             int suffixVersion = Integer.parseInt(suffixVersionString);
-            return new SuffixedVersion(major, minor, micro, qualifier, suffix, suffixVersion,
+            return new SuffixedVersion(major, minor, micro, qualifier, parseSuffix, suffixVersion,
                     version);
         }
     }

--- a/common/src/test/java/org/jboss/da/common/version/VersionAnalyzerTest.java
+++ b/common/src/test/java/org/jboss/da/common/version/VersionAnalyzerTest.java
@@ -155,12 +155,51 @@ public class VersionAnalyzerTest {
     }
 
     private void checkBMV(String expectedVersion, String version, String[] versions) {
-        VersionAnalyzer.VersionAnalysisResult result = versionFinder.analyseVersions(version,
+        checkBMV(versionFinder, expectedVersion, version, versions);
+    }
+
+    private void checkBMV(VersionAnalyzer versionAnalyzer, String expectedVersion, String version,
+            String[] versions) {
+        VersionAnalyzer.VersionAnalysisResult result = versionAnalyzer.analyseVersions(version,
                 Arrays.asList(versions));
 
         Optional<String> bmv = result.getBestMatchVersion();
         assertTrue("Best match version expected to be present", bmv.isPresent());
         assertEquals(expectedVersion, bmv.get());
+    }
+
+    @Test
+    public void testDifferentSuffix() {
+        VersionAnalyzer versionAnalyzer = new VersionAnalyzer(new VersionParser("temporary-redhat"));
+        String version = "1.4.0";
+        String expectedVersion = "1.4.0.temporary-redhat-1";
+
+        String[] avaliableVersionsOrder1 = { "1.4.0.redhat-1", "1.4.0.temporary-redhat-1" };
+        checkBMV(versionAnalyzer, expectedVersion, version, avaliableVersionsOrder1);
+
+        String[] avaliableVersionsOrder2 = { "1.4.0.temporary-redhat-1", "1.4.0.redhat-1" };
+        checkBMV(versionAnalyzer, expectedVersion, version, avaliableVersionsOrder2);
+
+        String[] avaliableVersionsMultiple = { "1.4.0.redhat-4", "1.4.0.redhat-3",
+                "1.4.0.redhat-2", "1.4.0.redhat-1", "1.4.0.temporary-redhat-1", };
+        checkBMV(versionAnalyzer, expectedVersion, version, avaliableVersionsMultiple);
+    }
+
+    @Test
+    public void testDifferentSuffixWithOnlyDefaultVersions() {
+        VersionAnalyzer versionAnalyzer = new VersionAnalyzer(new VersionParser(
+                "t20180522-115319-991-redhat"));
+        String version = "1.4.0";
+
+        String[] avaliableVersionsOrder1 = { "1.4.0.redhat-1", "1.4.0.temporary-redhat-1" };
+        checkBMV(versionAnalyzer, "1.4.0.redhat-1", version, avaliableVersionsOrder1);
+
+        String[] avaliableVersionsOrder2 = { "1.4.0.temporary-redhat-1", "1.4.0.redhat-1" };
+        checkBMV(versionAnalyzer, "1.4.0.redhat-1", version, avaliableVersionsOrder2);
+
+        String[] avaliableVersionsMultiple = { "1.4.0.redhat-4", "1.4.0.redhat-3",
+                "1.4.0.redhat-2", "1.4.0.redhat-1", "1.4.0.temporary-redhat-1", };
+        checkBMV(versionAnalyzer, "1.4.0.redhat-4", version, avaliableVersionsMultiple);
     }
 
 }

--- a/common/src/test/java/org/jboss/da/common/version/VersionParserTest.java
+++ b/common/src/test/java/org/jboss/da/common/version/VersionParserTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class VersioniParserTest {
+public class VersionParserTest {
 
     @Test
     public void testOSGIParser() {
@@ -45,18 +45,8 @@ public class VersioniParserTest {
 
     @Test
     public void testTemporarySuffix() {
-        List<String> versions = Arrays.asList("1.5.8", "1.5.8-patch-01", "1.6.1", "1.6.1-redhat-1",
-                "1.6.1-redhat-2", "1.6.4.redhat-2", "1.7.2-redhat-1", "1.7.2.redhat-2",
-                "1.7.2.redhat-3", "1.7.2.redhat-4", "1.7.5.redhat-1", "1.7.5.redhat-2",
-                "1.7.7.redhat-1", "1.7.7.redhat-2", "1.7.7.redhat-3", "1.7.7.redhat-4",
-                "1.7.10.redhat-1", "1.7.12.redhat-1", "1.7.14.redhat-1", "1.7.21.redhat-1",
-                "1.7.21.redhat-2", "1.7.21.redhat-3", "1.7.21.redhat-4", "1.7.21.redhat-5",
-                "1.7.21.redhat-6", "1.7.21.redhat-7", "1.7.21.redhat-8", "1.7.21.redhat-9",
-                "1.7.21.redhat-10", "1.7.21.t20180417-125043-536-redhat-1",
-                "1.7.21.t20180425-112559-465-redhat-1", "1.7.21.t20180425-124526-785-redhat-1",
-                "1.7.21.t20180501-120645-593-redhat-1", "1.7.21.t20180522-115319-991-redhat-1",
-                "1.7.21.temporary-redhat-1", "1.7.22.redhat-1", "1.7.22.redhat-2",
-                "1.7.24.t20180417-112259-362-redhat-1");
+        List<String> versions = Arrays.asList("1.5.8", "1.5.8-patch-01", "1.6.1",
+                "1.7.21.t20180522-115319-991-redhat-1");
 
         VersionParser vp = new VersionParser("t20180522-115319-991-redhat");
         List<String> filtered = versions.stream()
@@ -64,5 +54,22 @@ public class VersioniParserTest {
                 .collect(Collectors.toList());
         assertEquals(1, filtered.size());
         assertTrue(filtered.contains("1.7.21.t20180522-115319-991-redhat-1"));
+    }
+
+    @Test
+    public void testTemporaryAndRedhatSuffix() {
+        List<String> versions = Arrays.asList("1.5.8", "1.5.8-patch-01", "1.6.1", "1.6.1-redhat-1",
+                "1.6.1-redhat-2", "1.6.4.redhat-2", "1.7.21.t20180417-125043-536-redhat-1",
+                "1.7.21.t20180425-112559-465-redhat-1", "1.7.21.temporary-redhat-1");
+
+        VersionParser vp = new VersionParser("temporary-redhat");
+        List<String> filtered = versions.stream()
+                .filter(v -> vp.parse(v).isSuffixed())
+                .collect(Collectors.toList());
+        assertEquals(6, filtered.size());
+        assertTrue(filtered.contains("1.7.21.temporary-redhat-1"));
+        assertTrue(filtered.contains("1.6.4.redhat-2"));
+        assertTrue(filtered.contains("1.7.21.t20180425-112559-465-redhat-1"));
+        assertFalse(filtered.contains("1.5.8-patch-01"));
     }
 }


### PR DESCRIPTION
When different version suffix is used, it's usead as additional (priority)
suffix, not as an override for the default one.

suffix: null
 returned: redhat-1, redhat-2, ...
 bestmatch: redhat-2

suffix: foo
 returned: foo-1, redhat-1, redhat-2, ...
 bestmatch: foo-1