### PR TITLE
[NCL-4266] Fix order of filtering versions when finding Best Match

### DIFF
--- a/common/src/test/java/org/jboss/da/common/version/VersionAnalyzerTest.java
+++ b/common/src/test/java/org/jboss/da/common/version/VersionAnalyzerTest.java
@@ -154,6 +154,15 @@ public class VersionAnalyzerTest {
         checkBMV("1.0.0.redhat-3", "1", avaliableVersions100);
     }
 
+    @Test
+    public void NCL4266ReproducerTest() {
+        String[] avaliableVersions1 = { "2.2.3.redhat-00001", "2.2.0.temporary-redhat-00001",
+                "2.2.0.redhat-00001", "2.1.16.redhat-00001", "2.1.9.redhat-1", "2.1.9.redhat-001",
+                "2.1.3.redhat-001" };
+        checkBMV(new VersionAnalyzer(new VersionParser("temporary-redhat")), "2.2.3.redhat-00001",
+                "2.2.3", avaliableVersions1);
+    }
+
     private void checkBMV(String expectedVersion, String version, String[] versions) {
         checkBMV(versionFinder, expectedVersion, version, versions);
     }


### PR DESCRIPTION
In case where the list of available version contained versions with
non-default suffix but it was not matching* the query flag
onlyDefaultSuffixPresent fas falsy set to true.

* Example:
  suffix: "temporary-redhat"
  query: "1.0.0"
  available: "1.0.0.redhat-1", "2.3.4.temporary-redhat-1"

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
NA
* [x] Have you added unit tests for your change?
