### PR TITLE
[NCLSUP-132] Allow dash instead of dot as separator before MICRO in version parser

### DIFF
--- a/common/src/main/java/org/jboss/da/common/version/VersionParser.java
+++ b/common/src/main/java/org/jboss/da/common/version/VersionParser.java
@@ -16,9 +16,13 @@ public class VersionParser {
 
     private final Pattern versionPattern;
 
+    // single dot at the end of the version indicates ommited micro "0"
+    // NCLSUP-132 asks to allow dash instead of dot before micro
+    static final String RE_MICRO = "(\\.$|[.-](?<micro>[0-9]{1,9}))";
+
     // major.minor.micro.qualifier-suffix-X
     // numbers limited to max 9 digits, beacuse of integer limitatations
-    static final String RE_MMM = "((?<major>[0-9]{1,9})?(\\.(?<minor>[0-9]{1,9})(\\.(?<micro>[0-9]{1,9}))?)?)";
+    static final String RE_MMM = "((?<major>[0-9]{1,9})?(\\.(?<minor>[0-9]{1,9})" + RE_MICRO + "?)?)";
 
     static final String RE_QUALIFIER = "([.-]?(?<qualifier>.+?))";
 

--- a/common/src/test/java/org/jboss/da/common/version/VersionParserTest.java
+++ b/common/src/test/java/org/jboss/da/common/version/VersionParserTest.java
@@ -17,7 +17,6 @@ public class VersionParserTest {
         assertEquals("1.1.0", VersionParser.getOSGiVersion("1.1"));
         assertEquals("1.1.0.redhat-1", VersionParser.getOSGiVersion("1.1.redhat-1"));
         assertEquals("1.1.0.redhat-1", VersionParser.getOSGiVersion("1.1-redhat-1"));
-        assertEquals("1.1.0", VersionParser.getOSGiVersion("1.1"));
         assertEquals("1.1.0.Final", VersionParser.getOSGiVersion("1.1Final"));
         assertEquals("1.1.5.CR4", VersionParser.getOSGiVersion("1.1.5CR4"));
         assertEquals("1.1.0", VersionParser.getOSGiVersion("1.1."));

--- a/common/src/test/java/org/jboss/da/common/version/VersionParserTest.java
+++ b/common/src/test/java/org/jboss/da/common/version/VersionParserTest.java
@@ -23,6 +23,41 @@ public class VersionParserTest {
         assertEquals("1.1.0.CR4", VersionParser.getOSGiVersion("1.1.CR4"));
         assertEquals("1.1.0.final", VersionParser.getOSGiVersion("1.1-final"));
         assertEquals("1.1.0.final-redhat-1", VersionParser.getOSGiVersion("1.1.0.final-redhat-1"));
+        assertEquals("1.1.2", VersionParser.getOSGiVersion("1.1-2"));
+        assertEquals("1.1.2.Final", VersionParser.getOSGiVersion("1.1-2.Final"));
+        assertEquals("1.1.2.Final", VersionParser.getOSGiVersion("1.1-2-Final"));
+        assertEquals("1.1.2.Final-redhat-2", VersionParser.getOSGiVersion("1.1-2.Final-redhat-2"));
+        assertEquals("1.1.2.Final-redhat-2", VersionParser.getOSGiVersion("1.1-2-Final-redhat-2"));
+    }
+
+    @Test
+    public void testVersionParser() {
+        VersionParser versionParser = new VersionParser("redhat");
+        assertEquals(new SuffixedVersion(1, 1, 0, "Final", "1.1.Final"), versionParser.parse("1.1.Final"));
+        assertEquals(new SuffixedVersion(1, 1, 0, "", "1.1"), versionParser.parse("1.1"));
+        assertEquals(
+                new SuffixedVersion(1, 1, 0, "", "redhat", 1, "1.1.redhat-1"),
+                versionParser.parse("1.1.redhat-1"));
+        assertEquals(
+                new SuffixedVersion(1, 1, 0, "", "redhat", 1, "1.1-redhat-1"),
+                versionParser.parse("1.1-redhat-1"));
+        assertEquals(new SuffixedVersion(1, 1, 0, "Final", "1.1Final"), versionParser.parse("1.1Final"));
+        assertEquals(new SuffixedVersion(1, 1, 5, "CR4", "1.1.5CR4"), versionParser.parse("1.1.5CR4"));
+        assertEquals(new SuffixedVersion(1, 1, 0, "", "1.1."), versionParser.parse("1.1."));
+        assertEquals(new SuffixedVersion(1, 1, 0, "CR4", "1.1.CR4"), versionParser.parse("1.1.CR4"));
+        assertEquals(new SuffixedVersion(1, 1, 0, "final", "1.1-final"), versionParser.parse("1.1-final"));
+        assertEquals(
+                new SuffixedVersion(1, 1, 0, "final", "redhat", 1, "1.1.0.final-redhat-1"),
+                versionParser.parse("1.1.0.final-redhat-1"));
+        assertEquals(new SuffixedVersion(1, 1, 2, "", "1.1-2"), versionParser.parse("1.1-2"));
+        assertEquals(new SuffixedVersion(1, 1, 2, "Final", "1.1-2.Final"), versionParser.parse("1.1-2.Final"));
+        assertEquals(new SuffixedVersion(1, 1, 2, "Final", "1.1-2-Final"), versionParser.parse("1.1-2-Final"));
+        assertEquals(
+                new SuffixedVersion(1, 1, 2, "Final", "redhat", 2, "1.1-2.Final-redhat-2"),
+                versionParser.parse("1.1-2.Final-redhat-2"));
+        assertEquals(
+                new SuffixedVersion(1, 1, 2, "Final", "redhat", 2, "1.1-2-Final-redhat-2"),
+                versionParser.parse("1.1-2-Final-redhat-2"));
     }
 
     @Test

--- a/testsuite/src/test/java/org/jboss/da/test/client/rest/reports/BugReporoducerRemoteTestIT.java
+++ b/testsuite/src/test/java/org/jboss/da/test/client/rest/reports/BugReporoducerRemoteTestIT.java
@@ -22,6 +22,7 @@ public class BugReporoducerRemoteTestIT extends AbstractRestReportsTest {
     private static final String ENCODING = "utf-8";
 
     private static final String PATH_SCM = "/reports/scm";
+    private static final String PATH_LOOKUP_GAVS = "/reports/lookup/gavs";
 
     @Test
     public void testDA176() throws Exception {
@@ -56,6 +57,12 @@ public class BugReporoducerRemoteTestIT extends AbstractRestReportsTest {
         Response response = createClientRequest(PATH_SCM)
                 .post(Entity.json(FileUtils.readFileToString(jsonRequestFile, ENCODING)));
 
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testNCLSUP132() throws Exception {
+        Response response = assertResponseForRequest(PATH_LOOKUP_GAVS, "NCLSUP132");
         assertEquals(200, response.getStatus());
     }
 }

--- a/testsuite/src/test/rest/v-1/expectedResponse/reports/lookup/gavs/NCLSUP132.json
+++ b/testsuite/src/test/rest/v-1/expectedResponse/reports/lookup/gavs/NCLSUP132.json
@@ -1,0 +1,19 @@
+[
+    {
+        "bestMatchVersion": "13.0.1.redhat-2",
+        "availableVersions": [
+            "13.0.1.redhat-2",
+            "13.0.1-redhat-1",
+            "16.0.1.redhat-3",
+            "18.0.0.redhat-1",
+            "19.0.0.redhat-1",
+            "11.0.2-redhat-2",
+            "11.0.2-redhat-1"
+        ],
+        "blacklisted": false,
+        "whitelisted": [],
+        "groupId": "com.google.guava",
+        "artifactId": "guava",
+        "version": "13.0-1"
+    }
+]

--- a/testsuite/src/test/rest/v-1/request/reports/lookup/gavs/NCLSUP132.json
+++ b/testsuite/src/test/rest/v-1/request/reports/lookup/gavs/NCLSUP132.json
@@ -1,0 +1,11 @@
+{
+    "productNames": [],
+    "productVersionIds": [],
+    "gavs": [
+        {
+            "groupId": "com.google.guava",
+            "artifactId": "guava",
+            "version": "13.0-1"
+        }
+    ]
+}


### PR DESCRIPTION
### Checklist:

* [x] Have you added a note in the [CHANGELOG](https://github.com/project-ncl/dependency-analysis/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
