### PR TITLE
Changes to better deserialize JSON using the DTO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,11 @@
                 <artifactId>wiremock-standalone</artifactId>
                 <version>2.6.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.11.1</version>
+            </dependency>
             <!-- Test dependencies -->
 
             <!-- Metrics dependencies -->

--- a/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/reports/impl/ReportsGeneratorImpl.java
@@ -561,11 +561,7 @@ public class ReportsGeneratorImpl implements ReportsGenerator {
                     artifacts);
 
             return analyzedVersions.thenApply(
-                    (v) -> NPMLookupReport.builder()
-                            .npmPackage(a)
-                            .availableVersions(v.getAvailableVersions())
-                            .bestMatchVersion(v.getBestMatchVersion().orElse(null))
-                            .build());
+                    (v) -> new NPMLookupReport(a, v.getBestMatchVersion().orElse(null), v.getAvailableVersions()));
         }).collect(Collectors.toList());
 
         return FuturesUtil.joinFutures(futures);

--- a/reports-model/pom.xml
+++ b/reports-model/pom.xml
@@ -63,5 +63,10 @@
             <artifactId>jsonassert</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/MavenLookupResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/MavenLookupResult.java
@@ -4,16 +4,20 @@ import org.jboss.da.model.rest.GAV;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class MavenLookupResult {
 
     @NonNull
     @JsonUnwrapped
     private GAV gav;
 
-    private final String bestMatchVersion;
+    private String bestMatchVersion;
 
 }

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/NPMLookupResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/NPMLookupResult.java
@@ -1,6 +1,8 @@
 package org.jboss.da.lookup.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -8,11 +10,13 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import org.jboss.da.model.rest.NPMPackage;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class NPMLookupResult {
 
     @NonNull
     @JsonUnwrapped
     private NPMPackage npmPackage;
 
-    private final String bestMatchVersion;
+    private String bestMatchVersion;
 }

--- a/reports-model/src/main/java/org/jboss/da/reports/model/response/LookupReport.java
+++ b/reports-model/src/main/java/org/jboss/da/reports/model/response/LookupReport.java
@@ -1,72 +1,30 @@
 package org.jboss.da.reports.model.response;
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import org.jboss.da.listings.model.rest.RestProductInput;
 import org.jboss.da.model.rest.GAV;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
-
+@Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class LookupReport {
 
-    /*
-     * Manually unwrap 'gav' via getters so as not to confuse Swagger.
-     * 
-     * Also, use @JsonIgnore so that the getters and setters generated for 'gav' are also ignored by Jackson.
-     */
+    @JsonUnwrapped
     @NonNull
-    @JsonIgnore
     private GAV gav;
 
-    @Getter
-    @Setter
     private String bestMatchVersion;
-
-    @Getter
-    @Setter
     private List<String> availableVersions;
-
-    @Getter
-    @Setter
     private boolean blacklisted;
-
-    @Getter
-    @Setter
     private List<RestProductInput> whitelisted;
 
     public LookupReport(GAV gav) {
-        this.gav = gav;
-    }
-
-    // **************************************************************************
-    // Keep `getGroupId`, `getArtifactId`, and `getVersion` here for Swagger,
-    // and so that Jackson knows how to marshall 'gav' properly!
-    // **************************************************************************
-    public String getGroupId() {
-        return gav.getGroupId();
-    }
-
-    public String getArtifactId() {
-        return gav.getArtifactId();
-    }
-
-    public String getVersion() {
-        return gav.getVersion();
-    }
-
-    @JsonIgnore
-    public @NonNull GAV getGav() {
-        return this.gav;
-    }
-
-    @JsonIgnore
-    public void setGav(@NonNull GAV gav) {
         this.gav = gav;
     }
 }

--- a/reports-model/src/main/java/org/jboss/da/reports/model/response/NPMLookupReport.java
+++ b/reports-model/src/main/java/org/jboss/da/reports/model/response/NPMLookupReport.java
@@ -20,7 +20,8 @@ import org.jboss.da.model.rest.NPMPackage;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Data;
 
 /**
@@ -28,13 +29,14 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
-@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class NPMLookupReport {
 
     @JsonUnwrapped
-    private final NPMPackage npmPackage;
+    private NPMPackage npmPackage;
 
-    private final String bestMatchVersion;
+    private String bestMatchVersion;
 
-    private final List<String> availableVersions;
+    private List<String> availableVersions;
 }

--- a/reports-model/src/test/java/org/jboss/da/reports/model/response/ReportTest.java
+++ b/reports-model/src/test/java/org/jboss/da/reports/model/response/ReportTest.java
@@ -1,0 +1,77 @@
+package org.jboss.da.reports.model.response;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.jboss.da.lookup.model.MavenLookupResult;
+import org.jboss.da.lookup.model.NPMLookupResult;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import static org.assertj.core.api.Assertions.*;
+
+public class ReportTest {
+
+    private static final String EXPECTED_PATH = "src/test/resources/deserializeTest";
+
+    @Test
+    public void deserializeLookupReport() throws IOException {
+
+        Path fileJson = getJsonResponseFile(EXPECTED_PATH, "mavenLookupReport");
+        String content = Files.lines(fileJson).collect(Collectors.joining());
+
+        ObjectMapper mapper = new ObjectMapper();
+        LookupReport reported = mapper.readValue(content, LookupReport.class);
+
+        assertThat(reported.getGav()).isNotNull();
+        assertThat(reported.getGav().getArtifactId()).isEqualTo("xom");
+        assertThat(reported.getGav().getVersion()).isEqualTo("1.2.5");
+    }
+
+    @Test
+    public void deserializeLookupResult() throws IOException {
+
+        Path fileJson = getJsonResponseFile(EXPECTED_PATH, "mavenLookupResult");
+        String content = Files.lines(fileJson).collect(Collectors.joining());
+
+        ObjectMapper mapper = new ObjectMapper();
+        MavenLookupResult reported = mapper.readValue(content, MavenLookupResult.class);
+
+        assertThat(reported.getGav()).isNotNull();
+        assertThat(reported.getGav().getArtifactId()).isEqualTo("xom");
+        assertThat(reported.getGav().getVersion()).isEqualTo("1.2.5");
+    }
+
+    @Test
+    public void deserializeNPMLookupReport() throws IOException {
+
+        Path fileJson = getJsonResponseFile(EXPECTED_PATH, "npmLookupReport");
+        String content = Files.lines(fileJson).collect(Collectors.joining());
+
+        ObjectMapper mapper = new ObjectMapper();
+        NPMLookupReport reported = mapper.readValue(content, NPMLookupReport.class);
+        assertThat(reported.getNpmPackage()).isNotNull();
+        assertThat(reported.getNpmPackage().getVersion()).isEqualTo("1.2.3");
+    }
+
+    @Test
+    public void deserializeNPMLookupResult() throws IOException {
+
+        Path fileJson = getJsonResponseFile(EXPECTED_PATH, "npmLookupResult");
+        String content = Files.lines(fileJson).collect(Collectors.joining());
+
+        ObjectMapper mapper = new ObjectMapper();
+        NPMLookupResult reported = mapper.readValue(content, NPMLookupResult.class);
+        assertThat(reported.getNpmPackage()).isNotNull();
+        assertThat(reported.getNpmPackage().getVersion()).isEqualTo("1.2.3");
+    }
+
+    protected Path getJsonResponseFile(String path, String variant) {
+        return Paths.get(path, variant + ".json");
+    }
+}

--- a/reports-model/src/test/resources/deserializeTest/mavenLookupReport.json
+++ b/reports-model/src/test/resources/deserializeTest/mavenLookupReport.json
@@ -1,0 +1,17 @@
+{
+  "bestMatchVersion": null,
+  "availableVersions": [
+    "1.2.7.rocksand-4"
+  ],
+  "blacklisted": false,
+  "whitelisted": [
+    {
+      "name": "JAMIE",
+      "version": "6.4.12",
+      "supportStatus": "SUPERSEDED"
+    }
+  ],
+  "version": "1.2.5",
+  "groupId": "xom",
+  "artifactId": "xom"
+}

--- a/reports-model/src/test/resources/deserializeTest/mavenLookupResult.json
+++ b/reports-model/src/test/resources/deserializeTest/mavenLookupResult.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.2.5",
+  "groupId": "xom",
+  "artifactId": "xom",
+  "bestMatchVersion": null
+}

--- a/reports-model/src/test/resources/deserializeTest/npmLookupReport.json
+++ b/reports-model/src/test/resources/deserializeTest/npmLookupReport.json
@@ -1,0 +1,6 @@
+  {
+    "name": "abab",
+    "version": "1.2.3",
+    "bestMatchVersion": null,
+    "availableVersions": ["1.2.6.boom-bam-1"]
+  }

--- a/reports-model/src/test/resources/deserializeTest/npmLookupResult.json
+++ b/reports-model/src/test/resources/deserializeTest/npmLookupResult.json
@@ -1,0 +1,5 @@
+  {
+    "name": "abab",
+    "version": "1.2.3",
+    "bestMatchVersion": null
+  }


### PR DESCRIPTION
This change applies to:

- LookupReport
- NPMLookupReport

The changes are required to properly deserialize the JSON into the
objects for clients using the DTOs to deserialize.

While a few stuff were tried, it looks like Jackson is confused by the
combination of the 'Builder' pattern and '@JsonUnwrapped' annotation and
doesn't know what to do. To keep it simple, this commit removes the
`@Builder` annotation, and uses the 'NoArgsConstructor' to make sure
Jackson can deserialize properly.

Tests are written to make sure that the deserialization process works.

### Checklist:

* [ ] Have you added a note in the [Changelog](https://github.com/project-ncl/dependency-analysis/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
