### PR TITLE
Create super-classes for lookup results

### DIFF
--- a/reports-model/src/main/java/org/jboss/da/lookup/model/MavenLatestResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/MavenLatestResult.java
@@ -1,25 +1,25 @@
 package org.jboss.da.lookup.model;
 
+import lombok.EqualsAndHashCode;
 import org.jboss.da.model.rest.GAV;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MavenLatestResult {
-
-    @NonNull
-    @JsonUnwrapped
-    private GAV gav;
+public class MavenLatestResult extends MavenResult {
 
     private String latestVersion;
+
+    public MavenLatestResult(@NonNull GAV gav, String latestVersion) {
+        super(gav);
+        this.latestVersion = latestVersion;
+    }
 
 }

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/MavenLookupResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/MavenLookupResult.java
@@ -1,25 +1,25 @@
 package org.jboss.da.lookup.model;
 
+import lombok.EqualsAndHashCode;
 import org.jboss.da.model.rest.GAV;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MavenLookupResult {
-
-    @NonNull
-    @JsonUnwrapped
-    private GAV gav;
+public class MavenLookupResult extends MavenResult {
 
     private String bestMatchVersion;
+
+    public MavenLookupResult(@NonNull GAV gav, String bestMatchVersion) {
+        super(gav);
+        this.bestMatchVersion = bestMatchVersion;
+    }
 
 }

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/MavenResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/MavenResult.java
@@ -1,0 +1,21 @@
+package org.jboss.da.lookup.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.jboss.da.model.rest.GAV;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MavenResult {
+
+    @NonNull
+    @JsonUnwrapped
+    private GAV gav;
+
+}

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/MavenVersionsResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/MavenVersionsResult.java
@@ -16,9 +16,8 @@
 package org.jboss.da.lookup.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.jboss.da.model.rest.GAV;
@@ -29,17 +28,18 @@ import java.util.List;
  *
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MavenVersionsResult {
-
-    @NonNull
-    @JsonUnwrapped
-    private GAV gav;
+public class MavenVersionsResult extends MavenResult {
 
     @NonNull
     private List<String> availableVersions;
+
+    public MavenVersionsResult(@NonNull GAV gav, @NonNull List<String> availableVersions) {
+        super(gav);
+        this.availableVersions = availableVersions;
+    }
 
 }

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/NPMLookupResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/NPMLookupResult.java
@@ -2,23 +2,26 @@ package org.jboss.da.lookup.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
+import org.jboss.da.model.rest.GAV;
 import org.jboss.da.model.rest.NPMPackage;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class NPMLookupResult {
-
-    @NonNull
-    @JsonUnwrapped
-    private NPMPackage npmPackage;
+public class NPMLookupResult extends NPMResult {
 
     private String bestMatchVersion;
+
+    public NPMLookupResult(@NonNull NPMPackage npmPackage, String bestMatchVersion) {
+        super(npmPackage);
+        this.bestMatchVersion = bestMatchVersion;
+    }
 }

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/NPMResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/NPMResult.java
@@ -1,0 +1,21 @@
+package org.jboss.da.lookup.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.jboss.da.model.rest.NPMPackage;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NPMResult {
+
+    @NonNull
+    @JsonUnwrapped
+    private NPMPackage npmPackage;
+
+}

--- a/reports-model/src/main/java/org/jboss/da/lookup/model/NPMVersionsResult.java
+++ b/reports-model/src/main/java/org/jboss/da/lookup/model/NPMVersionsResult.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.jboss.da.model.rest.NPMPackage;
@@ -29,16 +30,17 @@ import java.util.List;
  *
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class NPMVersionsResult {
-
-    @NonNull
-    @JsonUnwrapped
-    private NPMPackage npmPackage;
+public class NPMVersionsResult extends NPMResult {
 
     @NonNull
     private List<String> availableVersions;
+
+    public NPMVersionsResult(@NonNull NPMPackage npmPackage, @NonNull List<String> availableVersions) {
+        super(npmPackage);
+        this.availableVersions = availableVersions;
+    }
 }


### PR DESCRIPTION
This change should help to eliminate order methods for every result type in bacon https://github.com/project-ncl/bacon/blob/main/da/src/main/java/org/jboss/bacon/da/DaHelper.java#L203