### PR TITLE
HTML fixes and correct version

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>application</artifactId>
   <packaging>jar</packaging>

--- a/application/src/main/resources/META-INF/resources/index.html
+++ b/application/src/main/resources/META-INF/resources/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
-        <title>dingrogu</title>
+        <title>Dependency Analysis</title>
         <style>
             body {
                 margin: 0;
@@ -237,6 +237,7 @@
                     <h1>Endpoints</h1>
                     <a href="/q/swagger-ui/" class="cta-button">Visit the Swagger UI</a>
                     <a href="/rest/v-1/version" class="cta-button">Version</a>
+                    <a href="/q/health" class="cta-button">Health Check</a>
                 </div>
             </div>
         </div>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>common</artifactId>
   <packaging>jar</packaging>

--- a/communication/pom.xml
+++ b/communication/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>communication</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.jboss.da</groupId>
   <artifactId>parent</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Dependency Analyzer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -264,16 +264,6 @@
             <groupId>org.commonjava.maven.galley</groupId>
             <artifactId>*</artifactId>
           </exclusion>
-          <!-- Avoid dragging in all of o11yphant. -->
-          <!-- Keeping o11yphant-metrics-api & o11yphant-trace-api for GalleyMavenProducer -->
-          <exclusion>
-            <groupId>org.commonjava.util</groupId>
-            <artifactId>o11yphant-trace-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.commonjava.util</groupId>
-            <artifactId>o11yphant-trace-helper-jhttpc</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/reports-backend/pom.xml
+++ b/reports-backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>reports-backend</artifactId>
   <packaging>jar</packaging>

--- a/reports-model/pom.xml
+++ b/reports-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>reports-model</artifactId>
   <packaging>jar</packaging>

--- a/reports-rest/pom.xml
+++ b/reports-rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>reports-rest</artifactId>
   <packaging>jar</packaging>

--- a/source-code-manager/pom.xml
+++ b/source-code-manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>source-code-manager</artifactId>
   <packaging>jar</packaging>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.da</groupId>
     <artifactId>parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>testsuite</artifactId>
   <name>testsuite</name>


### PR DESCRIPTION
Note - this version change to 3.0.0-SNAPSHOT supplant the change in #588 (changes from 2.7.0-SNAPSHOT to 3.2.0-SNAPSHOT) and #619 (change to 4.0.0-SNAPSHOT).
