### PR TITLE
Update maven-release to latest commit

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -13,7 +13,7 @@ jobs:
     call-release-job:
       permissions:
         contents: write # needed to push commit and tag back to the repository
-      uses: project-ncl/shared-github-actions/.github/workflows/maven-release.yml@f7041589cc1ce5e75564bda958cc6e5182c240cd # v0.0.15
+      uses: project-ncl/shared-github-actions/.github/workflows/maven-release.yml@daec766bf11d85450690879a7ae58774f02040b7 # main
       with:
         ref_to_release: ${{ inputs.ref_to_release }}
       secrets:


### PR DESCRIPTION
jboss-parent 53 by default wants to sign the tag. The latest maven-release action has something to prevent it

### Checklist:

* [ ] Have you added unit tests for your change?
