### PR TITLE
[NCLSUP-1440] Fix transaction rollback error in lookup endpoints

### DIFF
--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/BlackArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/BlackArtifactServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 import org.jboss.da.listings.api.dao.ArtifactDAO;
 import org.jboss.da.listings.api.dao.BlackArtifactDAO;
@@ -41,6 +42,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public Set<GAV> prefetchGAs(Set<org.jboss.da.model.rest.GA> gaToPrefetch) {
         if (gaToPrefetch.isEmpty()) {
             return Set.of();
@@ -63,6 +65,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public org.jboss.da.listings.api.service.ArtifactService.ArtifactStatus addArtifact(
             String groupId,
             String artifactId,
@@ -82,6 +85,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public Optional<BlackArtifact> getArtifact(String groupId, String artifactId, String version) {
         SuffixedVersion parsedVersion = versionParser.parse(version);
         Optional<BlackArtifact> artifact = blackArtifactDAO
@@ -108,6 +112,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public boolean removeArtifact(String groupId, String artifactId, String version) {
         Optional<BlackArtifact> artifact = blackArtifactDAO.findArtifact(groupId, artifactId, version);
         if (artifact.isPresent()) {
@@ -118,6 +123,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public SortedSet<BlackArtifact> getArtifacts(String groupId, String artifactId) {
         Comparator<BlackArtifact> baComparator = Comparator
                 .comparing((BlackArtifact a) -> versionParser.parse(a.getVersion()));

--- a/reports-rest/src/main/java/org/jboss/da/rest/LookupImpl.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/LookupImpl.java
@@ -3,7 +3,6 @@ package org.jboss.da.rest;
 import java.util.Set;
 
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 
 import org.jboss.da.common.CommunicationException;
 import org.jboss.da.lookup.model.MavenLatestRequest;
@@ -23,7 +22,6 @@ import org.slf4j.Logger;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 
-@Transactional
 public class LookupImpl implements Lookup {
 
     @Inject


### PR DESCRIPTION
Move @Transactional from REST layer to service layer to prevent transaction suspension issues.

Changes:
- Remove @Transactional from LookupImpl REST endpoint class
- Add @Transactional to BlackArtifactServiceImpl methods that perform database operations (prefetchGAs, addArtifact, getArtifact, removeArtifact, getArtifacts)

The transaction timeout is likely only 5 minutes. If the transaction starts at the REST endpoint level and Indy takes a long time to align, the transaction will already timeout by the end of the endpoint and fail.

This ensures database operations run in their own short-lived transactions while ProductProvider async operations execute completely outside of any transaction context, as designed.

### Checklist:

* [ ] Have you added unit tests for your change?
