### PR TITLE
 [NCLSUP-1440] Remove @transactional from REST facades to prevent timeout on long operations

### DIFF
--- a/reports-backend/src/main/java/org/jboss/da/listings/impl/service/BlackArtifactServiceImpl.java
+++ b/reports-backend/src/main/java/org/jboss/da/listings/impl/service/BlackArtifactServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 import org.jboss.da.listings.api.dao.ArtifactDAO;
 import org.jboss.da.listings.api.dao.BlackArtifactDAO;
@@ -41,6 +42,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public Set<GAV> prefetchGAs(Set<org.jboss.da.model.rest.GA> gaToPrefetch) {
         if (gaToPrefetch.isEmpty()) {
             return Set.of();
@@ -63,6 +65,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public org.jboss.da.listings.api.service.ArtifactService.ArtifactStatus addArtifact(
             String groupId,
             String artifactId,
@@ -82,6 +85,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public Optional<BlackArtifact> getArtifact(String groupId, String artifactId, String version) {
         SuffixedVersion parsedVersion = versionParser.parse(version);
         Optional<BlackArtifact> artifact = blackArtifactDAO
@@ -108,6 +112,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public boolean removeArtifact(String groupId, String artifactId, String version) {
         Optional<BlackArtifact> artifact = blackArtifactDAO.findArtifact(groupId, artifactId, version);
         if (artifact.isPresent()) {
@@ -118,6 +123,7 @@ public class BlackArtifactServiceImpl extends ArtifactServiceImpl<BlackArtifact>
     }
 
     @Override
+    @Transactional
     public SortedSet<BlackArtifact> getArtifacts(String groupId, String artifactId) {
         Comparator<BlackArtifact> baComparator = Comparator
                 .comparing((BlackArtifact a) -> versionParser.parse(a.getVersion()));

--- a/reports-rest/src/main/java/org/jboss/da/rest/LookupImpl.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/LookupImpl.java
@@ -3,7 +3,6 @@ package org.jboss.da.rest;
 import java.util.Set;
 
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 
 import org.jboss.da.common.CommunicationException;
 import org.jboss.da.lookup.model.MavenLatestRequest;
@@ -23,7 +22,6 @@ import org.slf4j.Logger;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 
-@Transactional
 public class LookupImpl implements Lookup {
 
     @Inject

--- a/reports-rest/src/main/java/org/jboss/da/rest/facade/ReportsFacade.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/facade/ReportsFacade.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 
 import org.apache.maven.scm.ScmException;
 import org.jboss.da.common.CommunicationException;
@@ -36,7 +35,6 @@ import org.jboss.da.validation.Validation;
 import org.jboss.da.validation.ValidationException;
 
 @ApplicationScoped
-@Transactional
 public class ReportsFacade {
 
     @Inject

--- a/reports-rest/src/main/java/org/jboss/da/rest/listings/BlackListImpl.java
+++ b/reports-rest/src/main/java/org/jboss/da/rest/listings/BlackListImpl.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.da.listings.api.model.BlackArtifact;
@@ -26,7 +25,6 @@ import io.opentelemetry.instrumentation.annotations.WithSpan;
  *
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
-@Transactional
 public class BlackListImpl implements BlackList {
 
     @Inject


### PR DESCRIPTION
Remove @transactional from ReportsFacade and BlackListImpl REST layer
classes to prevent transaction timeout issues with long-running operations.

ReportsFacade calls methods that:
- Perform SCM operations (git clone, checkout) which can be slow
- Use CompletableFuture for async operations
- Make HTTP calls to external systems (PNC, repositories)

Having @transactional at the REST layer caused the same issue as in
LookupImpl: transactions would timeout while waiting for async operations
or slow external calls to complete.

BlackListImpl had redundant @transactional since the underlying service
methods (BlackArtifactServiceImpl) now have their own transaction
management.

This ensures database operations have short-lived transactions while
long-running operations (SCM, HTTP, async) execute outside of any
transaction context.


### Checklist:

* [ ] Have you added unit tests for your change?
