### PR TITLE
Fix file handle leak in LocalRepo by closing Files.walk() streams

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/pom/LocalRepo.java
+++ b/communication/src/main/java/org/jboss/da/communication/pom/LocalRepo.java
@@ -84,17 +84,19 @@ public class LocalRepo {
     }
 
     public static Set<Path> getAllPoms(Path scmDir) throws IOException {
-        return Files.walk(scmDir)
-                .filter(p -> !Files.isDirectory(p)) // is file
-                .filter(p -> p.endsWith("pom.xml")) // named pom.xml
-                .collect(Collectors.toSet());
+        try (Stream<Path> walk = Files.walk(scmDir)) {
+            return walk.filter(p -> !Files.isDirectory(p)) // is file
+                    .filter(p -> p.endsWith("pom.xml")) // named pom.xml
+                    .collect(Collectors.toSet());
+        }
     }
 
     public synchronized Set<Path> getAllPoms() throws IOException {
-        return Files.walk(path)
-                .filter(p -> !Files.isDirectory(p)) // is file
-                .filter(p -> p.toString().endsWith(".pom")) // name ends with .pom
-                .collect(Collectors.toSet());
+        try (Stream<Path> walk = Files.walk(path)) {
+            return walk.filter(p -> !Files.isDirectory(p)) // is file
+                    .filter(p -> p.toString().endsWith(".pom")) // name ends with .pom
+                    .collect(Collectors.toSet());
+        }
     }
 
     protected void delete() throws IOException {


### PR DESCRIPTION
Files.walk() returns a Stream<Path> backed by DirectoryStream which holds file handles that must be closed. Failure to close these streams can lead to file descriptor exhaustion ("Too many open files" errors). Wrapped both getAllPoms() methods with try-with-resources to ensure proper cleanup.

### Checklist:

* [ ] Have you added unit tests for your change?
