### PR TITLE
[v3.0.x] Fix thread leak on dependency analysis

### DIFF
--- a/communication/src/main/java/org/jboss/da/communication/GalleyMavenProducer.java
+++ b/communication/src/main/java/org/jboss/da/communication/GalleyMavenProducer.java
@@ -6,8 +6,11 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 
 import org.commonjava.cdi.util.weft.config.DefaultWeftConfig;
@@ -42,6 +45,7 @@ import org.commonjava.util.partyline.Partyline;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 // Inspiration taken from the previous CartographyProducer and org.commonjava.maven.galley.embed.TestCDIProvider.java
+@ApplicationScoped
 public class GalleyMavenProducer {
 
     private FileTransportConfig fileTransportConfig;
@@ -52,10 +56,13 @@ public class GalleyMavenProducer {
 
     private PathGenerator pathGenerator;
 
+    private ScheduledExecutorService threadPool;
+
     @PostConstruct
     void init() {
         try {
             File file = Files.createTempDirectory("galley").toFile();
+            threadPool = Executors.newScheduledThreadPool(2);
 
             pathGenerator = new HashedLocationPathGenerator();
             cacheProvider = new PartyLineCacheProvider(
@@ -63,7 +70,7 @@ public class GalleyMavenProducer {
                     pathGenerator,
                     new NoOpFileEventManager(),
                     new TransferDecoratorManager(),
-                    Executors.newScheduledThreadPool(2),
+                    threadPool,
                     new Partyline());
             fileTransportConfig = new FileTransportConfig(file, pathGenerator);
 
@@ -72,6 +79,11 @@ public class GalleyMavenProducer {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        threadPool.shutdown();
     }
 
     @Produces

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
     <version>53</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>org.jboss.da</groupId>
@@ -98,7 +98,7 @@
     <version.io.opentelemetry.instrumentation>2.27.0</version.io.opentelemetry.instrumentation>
 
     <persistence.hibernate.hbm2ddl.auto>update</persistence.hibernate.hbm2ddl.auto>
-    <tagSuffix />
+    <tagSuffix/>
   </properties>
 
   <dependencyManagement>
@@ -557,7 +557,7 @@
         <version>3.4.0</version>
         <configuration>
           <java>
-            <removeUnusedImports />
+            <removeUnusedImports/>
             <importOrder>
               <file>java-import-order.txt</file>
             </importOrder>

--- a/reports-backend/src/main/java/org/jboss/da/products/impl/AggregatedProductProvider.java
+++ b/reports-backend/src/main/java/org/jboss/da/products/impl/AggregatedProductProvider.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -77,6 +78,11 @@ public class AggregatedProductProvider implements ProductProvider {
     PncProductProvider pncProductProvider;
 
     ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
+
+    @PreDestroy
+    public void preDestroy() {
+        scheduler.shutdown();
+    }
 
     @Override
     public CompletableFuture<Set<Product>> getAllProducts() {


### PR DESCRIPTION
Fix thread leak on DependencyAnalysis

We noticed in a thread and heap dump that there were around 2450 Timer
threads running and we couldn't create more threads inside the
container. Running `ls` would result with error:

```
sh: fork: retry: Resource temporarily unavailable
```

The container itself didn't reach the maximum memory usage, so it was
running out of threads!

After analyzing the heap dumps and thread dumps, those Timer threads
ultimately came from the `Partyline` objects which are only created in
`GalleyMavenProducer` inside the `@PostConstruct` method.

<img width="649" height="135" alt="Screenshot From 2026-06-22 17-24-58" src="https://github.com/user-attachments/assets/7678673f-f88c-4b59-9b2d-f2cb97d59865" />

<img width="654" height="82" alt="Screenshot From 2026-06-22 16-25-31" src="https://github.com/user-attachments/assets/fab177af-b174-4514-9517-04ebcee971b0" />

Morever, inside that method, a scheduled thread pool is created. They
can only be garbage collected if and only if they are shutdown.

We didn't explicitly shutdown those thread pools.

---

The GalleyMavenProducer has no class annotation and is therefore
considered `@Dependent`.

The only `@Produces` method really used by this class in other places in
DA is the `getObjectMapper` for `DefaultWebsocketEndpointHandler`
(annotated with `@ApplicationScoped`)

The weird behaviour with this setup is that a new `GalleyMavenProducer`
object is created whenever there's is a method call in
`DefaultWebsocketEndpointHandler`. Its `@PostConstruct` method is
therefore always called and a fresh `Partyline`, `thread pool`,
`PartylineCacheProvider` object are created.

---
The huge number of `Timer` threads shown in the threaddump revealed that
there was a huge number of Partyline objects created. One remaining
question is why aren't those objects being garbage collected after use?

The `Timer` thread in Partyline is never properly shutdown when
'Partline#stopRecording' is called, only the 'timer task' is
[https://github.com/Commonjava/partyline/blob/7050d2fd734b3d59c89ba0e1b2a8136a5685c09c/src/main/java/org/commonjava/util/partyline/Partyline.java#L204].
I believe it therefore keeps running, and since it holds a reference to
the Partyline object, the Partyline object cannot be gced.

I unfortunately cannot explain, from the heap dump I analyzed, why there
was only 2 scheduled thread pool count. In theory they need to also be
explicitly shutdown to be GC'ed. They were not previously, but there's
only 2. I don't get it.

---
This commit hopefully fixes the thread leak by:
- annotating this GalleyMavenProducer as `@ApplicationScoped` so that
  it's only created once. Therefore the `@PostConstruct` method is
  created only once and the Partyline and Scheduled thread pool created
  only once
- have a `@PreDestroy` method to properly cleanup the threadpool on
  shutdown

### Checklist:

* [ ] Have you added unit tests for your change?
